### PR TITLE
[#7] Implement Header and Footer layout components

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -3,7 +3,7 @@
 
 export default function AdminLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div>
+    <div className="fixed inset-0 bg-white z-50 overflow-auto">
       {/* Session check middleware added in Issue #7 */}
       {children}
     </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
+import Header from '@/components/layout/Header'
+import Footer from '@/components/layout/Footer'
 import './globals.css'
 
 const inter = Inter({ subsets: ['latin'] })
@@ -28,7 +30,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body className={inter.className}>
+        <Header />
         {children}
+        <Footer />
       </body>
     </html>
   )

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,10 +1,16 @@
-// Jules: implement in Issue #6
-// Footer with copyright, links to ernestofgaia.xyz
-
 export default function Footer() {
   return (
-    <footer>
-      {/* Implemented in Issue #6 */}
+    <footer className="border-t border-stone-200 px-6 py-8 text-sm text-stone-400">
+      <p>
+        © 2026 Ernest of Gaia ·{' '}
+        <a href="mailto:eog@ernestofgaia.xyz" className="hover:text-stone-700">
+          eog@ernestofgaia.xyz
+        </a>{' '}
+        ·{' '}
+        <a href="https://ernestofgaia.xyz" className="hover:text-stone-700">
+          ernestofgaia.xyz
+        </a>
+      </p>
     </footer>
-  )
+  );
 }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,10 +1,16 @@
-// Jules: implement in Issue #6
-// Header with site title and nav links (Home, About)
+import Link from 'next/link';
 
 export default function Header() {
   return (
-    <header>
-      {/* Implemented in Issue #6 */}
+    <header className="border-b border-stone-200 px-6 py-4 flex items-center justify-between">
+      <Link href="/" className="font-semibold text-stone-900 tracking-tight">
+        Ernest of Gaia
+      </Link>
+      <nav>
+        <Link href="/about" className="text-sm text-stone-500 hover:text-stone-900 transition-colors">
+          About
+        </Link>
+      </nav>
     </header>
-  )
+  );
 }


### PR DESCRIPTION
Fixes #7 by adding `Header` and `Footer` layout components, wiring them into the root layout to appear on all public pages, and modifying the admin layout to visually override these components.

---
*PR created automatically by Jules for task [10390022588727990358](https://jules.google.com/task/10390022588727990358) started by @ErnestOfGaia*