### PR TITLE
[#7] Admin auth — env-var password + session cookie

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,10 +1,12 @@
+import { requireAdmin } from '@/lib/auth'
+
 // Admin layout — enforces password session check for all /admin/* routes
 // Jules: implement session check in Issue #7
 
-export default function AdminLayout({ children }: { children: React.ReactNode }) {
+export default async function AdminLayout({ children }: { children: React.ReactNode }) {
+  await requireAdmin()
   return (
-    <div>
-      {/* Session check middleware added in Issue #7 */}
+    <div className="min-h-screen bg-white">
       {children}
     </div>
   )

--- a/src/app/api/admin/login/route.ts
+++ b/src/app/api/admin/login/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server'
+import { verifyPassword, sessionCookieOptions } from '@/lib/auth'
+
+export async function POST(request: Request) {
+  const formData = await request.formData()
+  const password = formData.get('password')
+
+  if (typeof password !== 'string' || !verifyPassword(password)) {
+    return NextResponse.redirect(new URL('/login?error=1', request.url), {
+      status: 303,
+    })
+  }
+
+  const response = NextResponse.redirect(new URL('/admin', request.url), {
+    status: 303,
+  })
+
+  response.cookies.set(sessionCookieOptions())
+
+  return response
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,46 @@
+export default async function LoginPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>
+}) {
+  const params = await searchParams;
+  const isError = params.error === '1';
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-white p-4">
+      <div className="w-full max-w-sm space-y-6">
+        <div className="text-center">
+          <h1 className="text-2xl font-semibold text-stone-900">Admin Login</h1>
+        </div>
+
+        <form action="/api/admin/login" method="POST" className="space-y-4">
+          <div>
+            <label htmlFor="password" className="block text-sm font-medium text-stone-700">
+              Password
+            </label>
+            <input
+              type="password"
+              id="password"
+              name="password"
+              required
+              className="mt-1 block w-full rounded-md border border-stone-300 px-3 py-2 text-stone-900 shadow-sm focus:border-stone-900 focus:outline-none focus:ring-1 focus:ring-stone-900 sm:text-sm"
+            />
+          </div>
+
+          {isError && (
+            <div className="text-red-600 text-sm">
+              Incorrect password.
+            </div>
+          )}
+
+          <button
+            type="submit"
+            className="flex w-full justify-center rounded-md border border-transparent bg-stone-900 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-stone-800 focus:outline-none focus:ring-2 focus:ring-stone-900 focus:ring-offset-2"
+          >
+            Log in
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -3,41 +3,26 @@ import { redirect } from 'next/navigation'
 import crypto from 'crypto'
 
 const COOKIE_NAME = 'admin_session'
-const COOKIE_MAX_AGE = 60 * 60 * 24 * 7 // 7 days
+const MAX_AGE = 60 * 60 * 24 * 7
 
-function hashPassword(password: string): string {
-  return crypto.createHash('sha256').update(password).digest('hex')
-}
-
-function getSessionToken(): string {
-  const password = process.env.ADMIN_PASSWORD ?? ''
-  return hashPassword(password + 'news-hub-session-salt')
+function getToken(): string {
+  return crypto.createHash('sha256')
+    .update((process.env.ADMIN_PASSWORD ?? '') + 'news-hub-salt').digest('hex')
 }
 
 export async function checkAdminSession(): Promise<boolean> {
-  const cookieStore = await cookies()
-  const session = cookieStore.get(COOKIE_NAME)
-  return session?.value === getSessionToken()
+  const store = await cookies()
+  return store.get(COOKIE_NAME)?.value === getToken()
 }
 
 export async function requireAdmin(): Promise<void> {
-  const isAdmin = await checkAdminSession()
-  if (!isAdmin) {
-    redirect('/admin/login')
-  }
-}
-
-export function createSessionCookie(): { name: string; value: string; maxAge: number; httpOnly: boolean; sameSite: 'strict' } {
-  return {
-    name: COOKIE_NAME,
-    value: getSessionToken(),
-    maxAge: COOKIE_MAX_AGE,
-    httpOnly: true,
-    sameSite: 'strict',
-  }
+  if (!(await checkAdminSession())) redirect('/login')
 }
 
 export function verifyPassword(input: string): boolean {
-  const correct = process.env.ADMIN_PASSWORD ?? ''
-  return input === correct
+  return input === (process.env.ADMIN_PASSWORD ?? '')
+}
+
+export function sessionCookieOptions() {
+  return { name: COOKIE_NAME, value: getToken(), httpOnly: true, sameSite: 'strict' as const, maxAge: MAX_AGE, path: '/' }
 }


### PR DESCRIPTION
Fixes Issue #7 (Admin auth — env-var password + session cookie).

Note: The login page was created at `/login` instead of `/admin/login` as suggested in the issue to avoid a redirect loop with the admin layout.

---
*PR created automatically by Jules for task [377759129487551963](https://jules.google.com/task/377759129487551963) started by @ErnestOfGaia*