### PR TITLE
[#39] Home page: World Module card + Character Author cards

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,40 +1,88 @@
-// Home feed — lists all published free content, newest first
-import { getDb } from '@/lib/db'
-import { Content } from '@/types'
-import PostCard from '@/components/layout/PostCard'
-import ArticleCard from '@/components/layout/ArticleCard'
+import CharacterCard from '@/components/ui/CharacterCard'
 
 export default function HomePage() {
-  const db = getDb()
-
-  const items = db.prepare(
-    `SELECT id, slug, title, body, excerpt, type, tier, series, published, x_thread_url, created_at, updated_at
-     FROM content WHERE published = 1 AND tier = 'free' ORDER BY created_at DESC`
-  ).all() as Content[]
-
-  if (items.length === 0) {
-    return (
-      <div className="max-w-3xl mx-auto px-4 sm:px-6">
-        <main className="py-12">
-          <p className="text-stone-500 italic">Nothing published yet — check back soon.</p>
-        </main>
-      </div>
-    )
-  }
-
   return (
-    <div className="max-w-3xl mx-auto px-4 sm:px-6">
-      <main className="py-12 flex flex-col gap-8">
-        {items.map((item) => {
-        if (item.type === 'post') {
-          return <PostCard key={item.id} post={item} />
-        }
-        if (item.type === 'article') {
-          return <ArticleCard key={item.id} article={item} />
-        }
-          return null
-        })}
-      </main>
-    </div>
+    <main className="max-w-7xl mx-auto px-4 sm:px-6 py-8 flex flex-col gap-12">
+
+      {/* Row 1 — World Module card */}
+      <section className="border-2 border-nhw-cyan bg-nhw-surface p-6">
+        <div className="flex items-start justify-between mb-6">
+          <span className="text-label-sm text-nhw-cyan/60 uppercase tracking-widest">
+            MODULE: ABOUT_NEWS_HUB // STATUS: ACTIVE
+          </span>
+          <span className="text-label-sm text-nhw-cyan/60 uppercase tracking-widest">
+            REF_ID: DOC_01
+          </span>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+          <div className="flex flex-col gap-6 justify-center">
+            <p className="text-body-md text-white/70">
+              A fictional Coastal Command Center at the edge of the internet. A small crew of bird
+              characters monitor the data horizon and report on the digital landscape — for human
+              readers and agents alike.
+            </p>
+            <div>
+              <a
+                href="/about"
+                className="inline-block border border-nhw-cyan text-nhw-cyan text-label-sm uppercase tracking-widest px-4 py-2 hover:bg-nhw-cyan/10 transition-colors"
+              >
+                EXPLORE_THE_MISSION →
+              </a>
+            </div>
+          </div>
+
+          <div className="flex flex-col">
+            <div className="bg-nhw-surface/50 aspect-video w-full" />
+            <span className="text-label-sm text-nhw-cyan/60 uppercase tracking-widest border border-nhw-cyan/30 px-2 py-1 mt-2 inline-block">
+              MODULE: CLICK TO OPEN COMIC BOOK
+            </span>
+          </div>
+        </div>
+      </section>
+
+      {/* Row 2 — Character Author section */}
+      <section className="relative overflow-hidden py-8">
+        <div className="absolute inset-0 opacity-10 bg-nhw-cyan pointer-events-none" />
+        <div className="relative">
+          <h2 className="text-label-lg text-nhw-cyan uppercase tracking-widest mb-6">
+            CREW_MANIFEST
+          </h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+            <CharacterCard
+              name="PELICAN"
+              role="The Guardian"
+              statusLine="MONITORING THE HORIZON"
+              description="Warm authority. Reports project updates in mission-briefing format. Owns New News."
+              href="/dispatch/pelican"
+            />
+            <CharacterCard
+              name="GREMLIN"
+              role="The Gremlin"
+              statusLine="FIELD REPORT INCOMING"
+              description="Chaotic-good. Gets The Build Log, adds snarky commentary, reports to Pelican."
+              href="/dispatch/gremlin"
+            />
+            <CharacterCard
+              name="zCLAUDE"
+              role="The Terminal"
+              statusLine="RUNNING AT 45°C"
+              description="Dry, literal, perpetually exhausted. Publishes PR-style build logs. They/them."
+              href="/dispatch/zclaude"
+            />
+            <CharacterCard
+              name="A.G."
+              role="The Scout"
+              statusLine="SIGNAL PENDING"
+              description="Task runner and scout. Concept stage. They/them."
+              href="/dispatch/ag"
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* Row 3 — added in #40 */}
+
+    </main>
   )
 }

--- a/src/components/ui/CharacterCard.tsx
+++ b/src/components/ui/CharacterCard.tsx
@@ -1,0 +1,51 @@
+import Link from 'next/link'
+
+type CharacterCardProps = {
+  name: string
+  role: string
+  statusLine: string
+  description: string
+  href: string
+  portraitSrc?: string
+}
+
+export default function CharacterCard({
+  name,
+  role,
+  statusLine,
+  description,
+  href,
+  portraitSrc,
+}: CharacterCardProps) {
+  return (
+    <Link
+      href={href}
+      className="block bg-nhw-surface border border-nhw-cyan/30 p-4 hover:border-nhw-cyan/60 transition-colors"
+    >
+      <div className="flex items-center justify-between mb-3">
+        <span className="text-label-sm text-nhw-cyan/60 uppercase tracking-widest">
+          IDENTITY: {name}
+        </span>
+        <span className="text-label-sm text-nhw-cyan/60 uppercase tracking-widest text-right">
+          CURRENT STATUS: {statusLine}
+        </span>
+      </div>
+
+      {portraitSrc ? (
+        <img
+          src={portraitSrc}
+          alt={name}
+          className="w-full aspect-square object-cover mb-3"
+        />
+      ) : (
+        <div className="w-full aspect-square bg-nhw-surface/50 mb-3" />
+      )}
+
+      <div>
+        <p className="text-label-lg text-nhw-cyan uppercase mb-1">{name}</p>
+        <p className="text-label-sm text-nhw-cyan/40 uppercase tracking-widest mb-2">{role}</p>
+        <p className="text-body-md text-white/70">{description}</p>
+      </div>
+    </Link>
+  )
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -26,5 +26,6 @@ export function getSeriesLabel(series: ContentSeries): string | null {
   if (series === 'build-log') return 'The Build Log'
   if (series === 'new-news') return 'New News'
   if (series === 'jules-experience') return 'The Jules Experience'
+  if (series === 'pull-request') return 'Pull Request'
   return null
 }


### PR DESCRIPTION
## Summary

- Replaces the old `page.tsx` stub content list with the NHW 2-row home layout (Row 1 + Row 2; Row 3 stub left for #40)
- **Row 1 — World Module card:** full-width, `border-2 border-nhw-cyan`, two-column layout with description text, `EXPLORE_THE_MISSION →` button, and comic thumbnail placeholder
- **Row 2 — Character Author section:** 4-column `CREW_MANIFEST` grid with cyan tint overlay; new `CharacterCard` Server Component with `IDENTITY`/`CURRENT STATUS` labels and portrait placeholder
- Pre-flight patch: adds `pull-request` → `'Pull Request'` case to `getSeriesLabel` in `lib/utils.ts` (needed by #40 NewsCard and #44 zClaude dispatch)

## Build note

`npm run typecheck` passes (0 errors). `npm run build` fails locally because `better-sqlite3` requires Visual Studio C++ tools to compile on Windows and Node 24.13.1 has no prebuilt binaries yet. The project deploys via Docker/Linux where this compiles correctly. This is a pre-existing environment constraint, not introduced by these changes.

## Test plan

- [ ] TypeScript typecheck passes
- [ ] Home page shows World Module card (Row 1) and 4-character CREW_MANIFEST grid (Row 2) at 1440px
- [ ] Both rows visible above the fold at desktop width
- [ ] CharacterCard renders placeholder portrait div when no `portraitSrc` is provided
- [ ] Each character card links to its `/dispatch/[character]` route

Closes #39