### PR TITLE
[#40] Home page: Latest Transmissions + navigation

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,15 @@
+import { getDb } from '@/lib/db'
+import { ContentSummary } from '@/types'
+import { getSeriesLabel } from '@/lib/utils'
 import CharacterCard from '@/components/ui/CharacterCard'
+import NewsCard from '@/components/ui/NewsCard'
 
 export default function HomePage() {
+  const db = getDb()
+  const latestItems = db.prepare(
+    `SELECT id, slug, title, excerpt, series, character, created_at
+     FROM content WHERE published = 1 AND tier = 'free' ORDER BY created_at DESC LIMIT 8`
+  ).all() as ContentSummary[]
   return (
     <main className="max-w-7xl mx-auto px-4 sm:px-6 py-8 flex flex-col gap-12">
 
@@ -81,7 +90,35 @@ export default function HomePage() {
         </div>
       </section>
 
-      {/* Row 3 — added in #40 */}
+      {/* Row 3 — Latest Transmissions */}
+      <section className="pb-20 md:pb-0">
+        <h2 className="text-label-lg text-nhw-cyan uppercase tracking-widest mb-6">
+          LATEST TRANSMISSIONS ──────────── ((•))
+        </h2>
+        {latestItems.length === 0 ? (
+          <p className="text-label-lg text-nhw-cyan/40 text-center py-12">
+            NO TRANSMISSIONS ON FILE
+          </p>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {latestItems.map((item) => {
+              const href = item.character
+                ? `/dispatch/${item.character}/${item.slug}`
+                : `/articles/${item.slug}`
+              return (
+                <NewsCard
+                  key={item.id}
+                  seriesLabel={getSeriesLabel(item.series)}
+                  date={item.created_at}
+                  headline={item.title}
+                  excerpt={item.excerpt}
+                  href={href}
+                />
+              )
+            })}
+          </div>
+        )}
+      </section>
 
     </main>
   )

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,18 +1,45 @@
-import Link from 'next/link';
+import Link from 'next/link'
+import NavLinks from './NavLinks'
+
+const NAV_LINKS = [
+  { href: '/', label: 'NEWS HUB WORLD' },
+  { href: '/signals', label: 'SIGNALS' },
+  { href: '/collected', label: 'COLLECTED' },
+  { href: '/settings', label: 'SETTINGS' },
+]
 
 export default function Header() {
   return (
-    <header className="border-b border-stone-200">
-      <div className="max-w-3xl mx-auto px-4 sm:px-6 py-4 flex items-center justify-between">
-        <Link href="/" className="font-semibold text-stone-900 tracking-tight">
-          Ernest of Gaia
-        </Link>
-        <nav>
-          <Link href="/about" className="text-sm text-stone-500 hover:text-stone-900 transition-colors">
-            About
+    <>
+      <header className="bg-nhw-bg border-b border-nhw-cyan/20 sticky top-0 z-40">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 py-4 flex items-center justify-between">
+          <Link
+            href="/"
+            className="text-label-lg text-nhw-cyan uppercase tracking-widest hover:opacity-80 transition-opacity"
+          >
+            COASTAL COMMAND CENTER
           </Link>
-        </nav>
-      </div>
-    </header>
-  );
+          <NavLinks
+            links={NAV_LINKS}
+            className="hidden md:flex items-center gap-6"
+            itemClassName="text-label-sm text-nhw-cyan/60 uppercase tracking-widest hover:text-nhw-cyan transition-colors pb-0.5 border-b-2 border-transparent"
+            activeClassName="text-nhw-cyan border-b-2 border-nhw-cyan"
+          />
+        </div>
+      </header>
+
+      {/* Mobile bottom nav */}
+      <nav className="md:hidden fixed bottom-0 left-0 right-0 z-40 bg-nhw-bg border-t border-nhw-cyan/20 flex">
+        {NAV_LINKS.map((link) => (
+          <Link
+            key={link.href}
+            href={link.href}
+            className="flex-1 flex items-center justify-center py-3 text-label-sm text-nhw-cyan/60 uppercase tracking-widest hover:text-nhw-cyan transition-colors"
+          >
+            {link.label}
+          </Link>
+        ))}
+      </nav>
+    </>
+  )
 }

--- a/src/components/layout/NavLinks.tsx
+++ b/src/components/layout/NavLinks.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+
+type NavLink = {
+  href: string
+  label: string
+}
+
+type NavLinksProps = {
+  links: NavLink[]
+  className?: string
+  itemClassName?: string
+  activeClassName?: string
+}
+
+export default function NavLinks({
+  links,
+  className,
+  itemClassName,
+  activeClassName,
+}: NavLinksProps) {
+  const pathname = usePathname()
+
+  return (
+    <nav className={className}>
+      {links.map((link) => {
+        const isActive = pathname === link.href || pathname.startsWith(link.href + '/')
+        return (
+          <Link
+            key={link.href}
+            href={link.href}
+            className={`${itemClassName ?? ''} ${isActive ? (activeClassName ?? '') : ''}`.trim()}
+          >
+            {link.label}
+          </Link>
+        )
+      })}
+    </nav>
+  )
+}

--- a/src/components/ui/NewsCard.tsx
+++ b/src/components/ui/NewsCard.tsx
@@ -1,0 +1,38 @@
+import Link from 'next/link'
+import { formatDate } from '@/lib/utils'
+
+type NewsCardProps = {
+  seriesLabel: string | null
+  date: string
+  headline: string
+  excerpt: string | null
+  href: string
+}
+
+export default function NewsCard({ seriesLabel, date, headline, excerpt, href }: NewsCardProps) {
+  return (
+    <article className="bg-nhw-surface border border-nhw-cyan/20 p-4 flex flex-col gap-3">
+      <div className="flex items-start justify-between gap-2">
+        {seriesLabel ? (
+          <span className="bg-nhw-amber/10 text-nhw-amber border border-nhw-amber/30 text-label-sm uppercase tracking-widest px-2 py-0.5">
+            {seriesLabel}
+          </span>
+        ) : (
+          <span />
+        )}
+        <time className="text-label-sm text-nhw-cyan/60 shrink-0">{formatDate(date)}</time>
+      </div>
+
+      <h3 className="text-label-lg text-nhw-cyan uppercase tracking-widest">{headline}</h3>
+
+      {excerpt && <p className="text-body-md text-white/70">{excerpt}</p>}
+
+      <Link
+        href={href}
+        className="text-label-sm text-nhw-cyan hover:opacity-70 transition-opacity mt-auto"
+      >
+        READ_SIGNAL &gt;
+      </Link>
+    </article>
+  )
+}


### PR DESCRIPTION
## Summary

- **Row 3 — Latest Transmissions:** DB query for latest 8 published free items, rendered as a 2-column `NewsCard` grid with amber series chips and `READ_SIGNAL >` links
- **NewsCard** Server Component: amber series chip, date (right-aligned), headline, excerpt, link
- **Header** — full NHW restyle: `COASTAL COMMAND CENTER` brand, `bg-nhw-bg border-nhw-cyan/20`, all stone colors replaced with NHW tokens
- **NavLinks** — thin `use client` wrapper using `usePathname()` to apply `border-b-2 border-nhw-cyan` active state on matching route
- **Mobile bottom nav** — `md:hidden` fixed bottom bar with four equal nav buttons; page adds `pb-20` on mobile to prevent overlap

## Build note

`npm run typecheck` passes (0 errors). `npm run build` fails locally because `better-sqlite3` requires Visual Studio C++ tools on Windows (Node 24.13.1 has no prebuilt binaries). Pre-existing environment constraint; Docker/Linux deployment unaffected.

## Test plan

- [ ] TypeScript typecheck passes
- [ ] Home page shows all 3 rows at 1440px desktop (both rows 1+2 visible above fold)
- [ ] Row 3 shows empty state `NO TRANSMISSIONS ON FILE` when DB has no published content
- [ ] Header brand reads `COASTAL COMMAND CENTER` in nhw-cyan
- [ ] Active nav link has cyan underline on matching route
- [ ] Mobile bottom nav appears below md breakpoint and does not overlap content

Closes #40