### PR TITLE
[#41] Wire ComicStripViewer to World Module card

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@ import { ContentSummary } from '@/types'
 import { getSeriesLabel } from '@/lib/utils'
 import CharacterCard from '@/components/ui/CharacterCard'
 import NewsCard from '@/components/ui/NewsCard'
+import WorldModuleComic from '@/components/ui/WorldModuleComic'
 
 export default function HomePage() {
   const db = getDb()
@@ -41,12 +42,7 @@ export default function HomePage() {
             </div>
           </div>
 
-          <div className="flex flex-col">
-            <div className="bg-nhw-surface/50 aspect-video w-full" />
-            <span className="text-label-sm text-nhw-cyan/60 uppercase tracking-widest border border-nhw-cyan/30 px-2 py-1 mt-2 inline-block">
-              MODULE: CLICK TO OPEN COMIC BOOK
-            </span>
-          </div>
+          <WorldModuleComic />
         </div>
       </section>
 

--- a/src/components/ui/WorldModuleComic.tsx
+++ b/src/components/ui/WorldModuleComic.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { useState } from 'react'
+import ComicStripViewer from './ComicStripViewer'
+
+// TODO: add panel paths to NEWSY_PANELS when assets are in public/comics/newsy/
+const NEWSY_PANELS: string[] = []
+
+export default function WorldModuleComic() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <div className="flex flex-col">
+      <button
+        onClick={() => setOpen(true)}
+        className="bg-nhw-surface/50 aspect-video w-full hover:bg-nhw-surface/70 transition-colors cursor-pointer"
+        aria-label="Open comic viewer"
+      />
+      <span className="text-label-sm text-nhw-cyan/60 uppercase tracking-widest border border-nhw-cyan/30 px-2 py-1 mt-2 inline-block hover:border-nhw-cyan/60 transition-colors">
+        MODULE: CLICK TO OPEN COMIC BOOK
+      </span>
+
+      {open && (
+        <ComicStripViewer
+          panels={NEWSY_PANELS}
+          tier="free"
+          onClose={() => setOpen(false)}
+        />
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- New `WorldModuleComic` (`use client`) manages open/close state for the comic viewer island in the World Module card's right column
- `NEWSY_PANELS` is an empty array with a `TODO` comment — clicking the placeholder opens the viewer and shows the existing `NO_PANELS_CONFIGURED` message from `ComicStripViewer`
- `page.tsx` stays a Server Component; `WorldModuleComic` is imported as a Client Component child
- Panel assets go in `public/comics/newsy/` when ready — no other code change needed

## Build note

`npm run typecheck` passes (0 errors). `npm run build` fails locally due to `better-sqlite3` native compilation (Windows/Node 24 — pre-existing constraint, not introduced here).

## Test plan

- [ ] TypeScript typecheck passes
- [ ] World Module card right column renders a clickable placeholder area and label
- [ ] Clicking the placeholder opens the full-screen `ComicStripViewer` showing `NO_PANELS_CONFIGURED`
- [ ] Pressing Escape or the ✕ button closes the viewer
- [ ] `page.tsx` has no `use client` directive

Closes #41