### PR TITLE
[#42] Pelican Dispatch page

### DIFF
--- a/src/app/dispatch/pelican/[slug]/page.tsx
+++ b/src/app/dispatch/pelican/[slug]/page.tsx
@@ -1,0 +1,65 @@
+import { notFound } from 'next/navigation'
+import { getDb } from '@/lib/db'
+import { Content } from '@/types'
+import { formatDate, getSeriesLabel } from '@/lib/utils'
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import MarkdownRenderer from '@/components/ui/MarkdownRenderer'
+
+type Props = {
+  params: Promise<{ slug: string }>
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params
+  const db = getDb()
+  const post = db.prepare(
+    `SELECT title, excerpt FROM content WHERE character = 'pelican' AND slug = ? AND published = 1`
+  ).get(slug) as Pick<Content, 'title' | 'excerpt'> | undefined
+
+  if (!post) return {}
+  return {
+    title: post.title,
+    description: post.excerpt ?? undefined,
+  }
+}
+
+export default async function PelicanPostPage({ params }: Props) {
+  const { slug } = await params
+  const db = getDb()
+  const post = db.prepare(
+    `SELECT * FROM content WHERE character = 'pelican' AND slug = ? AND published = 1`
+  ).get(slug) as Content | undefined
+
+  if (!post) notFound()
+
+  const seriesLabel = getSeriesLabel(post.series)
+
+  return (
+    <main className="max-w-3xl mx-auto px-4 sm:px-6 py-8 flex flex-col gap-8">
+      <Link
+        href="/dispatch/pelican"
+        className="text-label-sm text-nhw-cyan hover:opacity-70 transition-opacity"
+      >
+        ← PELICAN&apos;S DISPATCH
+      </Link>
+
+      <header className="flex flex-col gap-3">
+        <div className="flex items-center gap-3">
+          <span className="text-label-sm text-nhw-cyan/60 uppercase tracking-widest">
+            PELICAN — THE GUARDIAN
+          </span>
+          {seriesLabel && (
+            <span className="bg-nhw-amber/10 text-nhw-amber border border-nhw-amber/30 text-label-sm uppercase tracking-widest px-2 py-0.5">
+              {seriesLabel}
+            </span>
+          )}
+        </div>
+        <h1 className="text-headline-lg text-nhw-cyan uppercase">{post.title}</h1>
+        <time className="text-label-sm text-nhw-cyan/60">{formatDate(post.created_at)}</time>
+      </header>
+
+      <MarkdownRenderer content={post.body} />
+    </main>
+  )
+}

--- a/src/app/dispatch/pelican/page.tsx
+++ b/src/app/dispatch/pelican/page.tsx
@@ -1,0 +1,67 @@
+import { getDb } from '@/lib/db'
+import { ContentSummary } from '@/types'
+import { formatDate, getSeriesLabel } from '@/lib/utils'
+import Link from 'next/link'
+import CharacterCard from '@/components/ui/CharacterCard'
+
+export default function PelicanDispatchPage() {
+  const db = getDb()
+  const posts = db.prepare(
+    `SELECT id, slug, title, excerpt, series, character, created_at
+     FROM content WHERE character = 'pelican' AND published = 1 ORDER BY created_at DESC`
+  ).all() as ContentSummary[]
+
+  return (
+    <main className="max-w-7xl mx-auto px-4 sm:px-6 py-8 flex flex-col gap-10">
+      <CharacterCard
+        name="PELICAN"
+        role="The Guardian"
+        statusLine="MONITORING THE HORIZON"
+        description="Warm authority. Reports project updates in mission-briefing format. Owns New News."
+        href="/dispatch/pelican"
+      />
+
+      <section>
+        <h2 className="text-label-lg text-nhw-cyan uppercase tracking-widest mb-6">
+          TRANSMISSIONS ──────────── ((•))
+        </h2>
+
+        {posts.length === 0 ? (
+          <p className="text-label-lg text-nhw-cyan/40 text-center py-12">
+            NO TRANSMISSIONS ON FILE
+          </p>
+        ) : (
+          <div className="flex flex-col gap-6">
+            {posts.map((post) => {
+              const seriesLabel = getSeriesLabel(post.series)
+              return (
+                <article key={post.id} className="flex flex-col gap-2 border-b border-nhw-cyan/10 pb-6">
+                  <div className="flex items-center gap-3">
+                    <span className="text-label-sm text-nhw-cyan/60 uppercase tracking-widest">
+                      STATUS: ACTIVE // {formatDate(post.created_at)}
+                    </span>
+                    {seriesLabel && (
+                      <span className="bg-nhw-amber/10 text-nhw-amber border border-nhw-amber/30 text-label-sm uppercase tracking-widest px-2 py-0.5">
+                        {seriesLabel}
+                      </span>
+                    )}
+                  </div>
+                  <h3 className="text-headline-md text-nhw-cyan uppercase">{post.title}</h3>
+                  {post.excerpt && (
+                    <p className="text-body-md text-white/70">{post.excerpt}</p>
+                  )}
+                  <Link
+                    href={`/dispatch/pelican/${post.slug}`}
+                    className="text-label-sm text-nhw-cyan hover:opacity-70 transition-opacity"
+                  >
+                    READ_SIGNAL &gt;
+                  </Link>
+                </article>
+              )
+            })}
+          </div>
+        )}
+      </section>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary

- `/dispatch/pelican` — list page: `CharacterCard` header with Pelican values, `TRANSMISSIONS ──────────── ((•))` section, post items showing `STATUS: ACTIVE // [date]`, series chip, headline in `headline-md`, excerpt, `READ_SIGNAL >` link; empty state `NO TRANSMISSIONS ON FILE`
- `/dispatch/pelican/[slug]` — post page: back link `← PELICAN'S DISPATCH`, byline `PELICAN — THE GUARDIAN` + amber series chip, `headline-lg` title, date, `MarkdownRenderer` body
- `notFound()` on missing or unpublished slug; `generateMetadata` sets page title from post

## Build note

`npm run typecheck` passes (0 errors). `npm run build` fails locally due to `better-sqlite3` native compilation (Windows/Node 24 — pre-existing constraint).

## Test plan

- [ ] TypeScript typecheck passes
- [ ] `/dispatch/pelican` renders CharacterCard at top and empty state when no Pelican content exists
- [ ] `/dispatch/pelican/some-slug` returns 404 for unknown slug
- [ ] Individual post renders MarkdownRenderer body and back link

Closes #42