### PR TITLE
[#43] Gremlin Dispatch page

### DIFF
--- a/src/app/dispatch/gremlin/[slug]/page.tsx
+++ b/src/app/dispatch/gremlin/[slug]/page.tsx
@@ -1,0 +1,65 @@
+import { notFound } from 'next/navigation'
+import { getDb } from '@/lib/db'
+import { Content } from '@/types'
+import { formatDate, getSeriesLabel } from '@/lib/utils'
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import MarkdownRenderer from '@/components/ui/MarkdownRenderer'
+
+type Props = {
+  params: Promise<{ slug: string }>
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params
+  const db = getDb()
+  const post = db.prepare(
+    `SELECT title, excerpt FROM content WHERE character = 'gremlin' AND slug = ? AND published = 1`
+  ).get(slug) as Pick<Content, 'title' | 'excerpt'> | undefined
+
+  if (!post) return {}
+  return {
+    title: post.title,
+    description: post.excerpt ?? undefined,
+  }
+}
+
+export default async function GremlinPostPage({ params }: Props) {
+  const { slug } = await params
+  const db = getDb()
+  const post = db.prepare(
+    `SELECT * FROM content WHERE character = 'gremlin' AND slug = ? AND published = 1`
+  ).get(slug) as Content | undefined
+
+  if (!post) notFound()
+
+  const seriesLabel = getSeriesLabel(post.series)
+
+  return (
+    <main className="max-w-3xl mx-auto px-4 sm:px-6 py-8 flex flex-col gap-8">
+      <Link
+        href="/dispatch/gremlin"
+        className="text-label-sm text-nhw-cyan hover:opacity-70 transition-opacity"
+      >
+        ← GREMLIN&apos;S DISPATCH
+      </Link>
+
+      <header className="flex flex-col gap-3 border-l-2 border-nhw-amber pl-4">
+        <div className="flex items-center gap-3">
+          <span className="text-label-sm text-nhw-cyan/60 uppercase tracking-widest">
+            GREMLIN — THE GREMLIN
+          </span>
+          {seriesLabel && (
+            <span className="bg-nhw-amber/10 text-nhw-amber border border-nhw-amber/30 text-label-sm uppercase tracking-widest px-2 py-0.5">
+              {seriesLabel}
+            </span>
+          )}
+        </div>
+        <h1 className="text-headline-lg text-nhw-cyan uppercase">{post.title}</h1>
+        <time className="text-label-sm text-nhw-amber/60">{formatDate(post.created_at)}</time>
+      </header>
+
+      <MarkdownRenderer content={post.body} />
+    </main>
+  )
+}

--- a/src/app/dispatch/gremlin/page.tsx
+++ b/src/app/dispatch/gremlin/page.tsx
@@ -1,0 +1,72 @@
+import { getDb } from '@/lib/db'
+import { ContentSummary } from '@/types'
+import { formatDate, getSeriesLabel } from '@/lib/utils'
+import Link from 'next/link'
+import CharacterCard from '@/components/ui/CharacterCard'
+
+export default function GremlinDispatchPage() {
+  const db = getDb()
+  const posts = db.prepare(
+    `SELECT id, slug, title, excerpt, series, character, created_at
+     FROM content WHERE character = 'gremlin' AND published = 1 ORDER BY created_at DESC`
+  ).all() as ContentSummary[]
+
+  return (
+    <main className="max-w-7xl mx-auto px-4 sm:px-6 py-8 flex flex-col gap-10">
+      <CharacterCard
+        name="GREMLIN"
+        role="The Gremlin"
+        statusLine="FIELD REPORT INCOMING"
+        description="Chaotic-good. Gets The Build Log, adds snarky commentary, reports to Pelican."
+        href="/dispatch/gremlin"
+      />
+
+      <section>
+        <h2 className="text-label-lg text-nhw-cyan uppercase tracking-widest mb-6">
+          TRANSMISSIONS ──────────── ((•))
+        </h2>
+
+        {posts.length === 0 ? (
+          <p className="text-label-lg text-nhw-cyan/40 text-center py-12">
+            NO TRANSMISSIONS ON FILE
+          </p>
+        ) : (
+          <div className="flex flex-col gap-6">
+            {posts.map((post) => {
+              const seriesLabel = getSeriesLabel(post.series)
+              return (
+                <article
+                  key={post.id}
+                  className="border-l-2 border-nhw-amber pl-4 flex flex-col gap-2"
+                >
+                  <div className="flex items-center gap-3">
+                    <span className="text-label-sm text-nhw-amber/60 uppercase tracking-widest">
+                      FIELD LOG — {formatDate(post.created_at)}
+                    </span>
+                    {seriesLabel && (
+                      <span className="bg-nhw-amber/10 text-nhw-amber border border-nhw-amber/30 text-label-sm uppercase tracking-widest px-2 py-0.5">
+                        {seriesLabel}
+                      </span>
+                    )}
+                  </div>
+                  <h3 className="text-label-lg text-nhw-cyan uppercase tracking-widest">
+                    {post.title}
+                  </h3>
+                  {post.excerpt && (
+                    <p className="text-body-md text-white/70">{post.excerpt}</p>
+                  )}
+                  <Link
+                    href={`/dispatch/gremlin/${post.slug}`}
+                    className="text-label-sm text-nhw-cyan hover:opacity-70 transition-opacity"
+                  >
+                    READ_FULL_REPORT &gt;
+                  </Link>
+                </article>
+              )
+            })}
+          </div>
+        )}
+      </section>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary

- `/dispatch/gremlin` — list page with `CharacterCard` header and amber `border-l-2 border-nhw-amber` accent on each post item; `FIELD LOG — [date]` header in `text-nhw-amber/60`; `READ_FULL_REPORT >` link; empty state
- `/dispatch/gremlin/[slug]` — back link `← GREMLIN'S DISPATCH`; header block with amber left border; `GREMLIN — THE GREMLIN` byline + series chip; `MarkdownRenderer` body
- Visual distinction from Pelican: amber left-border accent and amber date text throughout

## Build note

`npm run typecheck` passes (0 errors). `npm run build` fails locally due to `better-sqlite3` native compilation (Windows/Node 24 — pre-existing constraint).

## Test plan

- [ ] TypeScript typecheck passes
- [ ] `/dispatch/gremlin` shows amber border-l-2 accent on post items
- [ ] Empty state shows `NO TRANSMISSIONS ON FILE`
- [ ] Individual post has amber accent header and back link

Closes #43