### PR TITLE
[#44] zClaude Dispatch page

### DIFF
--- a/src/app/dispatch/zclaude/[slug]/page.tsx
+++ b/src/app/dispatch/zclaude/[slug]/page.tsx
@@ -1,0 +1,78 @@
+import { notFound } from 'next/navigation'
+import { getDb } from '@/lib/db'
+import { Content } from '@/types'
+import { formatDate, getSeriesLabel } from '@/lib/utils'
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import MarkdownRenderer from '@/components/ui/MarkdownRenderer'
+
+type Props = {
+  params: Promise<{ slug: string }>
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params
+  const db = getDb()
+  const post = db.prepare(
+    `SELECT title, excerpt FROM content WHERE character = 'zclaude' AND slug = ? AND published = 1`
+  ).get(slug) as Pick<Content, 'title' | 'excerpt'> | undefined
+
+  if (!post) return {}
+  return {
+    title: post.title,
+    description: post.excerpt ?? undefined,
+  }
+}
+
+export default async function ZClaudePostPage({ params }: Props) {
+  const { slug } = await params
+  const db = getDb()
+  const post = db.prepare(
+    `SELECT * FROM content WHERE character = 'zclaude' AND slug = ? AND published = 1`
+  ).get(slug) as Content | undefined
+
+  if (!post) notFound()
+
+  const seriesLabel = getSeriesLabel(post.series)
+
+  return (
+    <main className="max-w-3xl mx-auto px-4 sm:px-6 py-8 flex flex-col gap-8">
+      <Link
+        href="/dispatch/zclaude"
+        className="text-label-sm text-nhw-cyan hover:opacity-70 transition-opacity"
+      >
+        ← zCLAUDE&apos;S DISPATCH
+      </Link>
+
+      <header className="flex flex-col gap-3">
+        <div className="flex items-center gap-3">
+          <span className="text-label-sm text-nhw-cyan/40 border border-nhw-cyan/20 px-2 uppercase tracking-widest">
+            PULL REQUEST
+          </span>
+          {seriesLabel && (
+            <span className="bg-nhw-amber/10 text-nhw-amber border border-nhw-amber/30 text-label-sm uppercase tracking-widest px-2 py-0.5">
+              {seriesLabel}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-3">
+          <span className="text-label-sm text-nhw-cyan/60 uppercase tracking-widest">
+            zCLAUDE — THEY/THEM
+          </span>
+        </div>
+        <h1 className="text-headline-lg text-nhw-cyan uppercase">{post.title}</h1>
+        <time className="text-label-sm text-nhw-cyan/60">{formatDate(post.created_at)}</time>
+      </header>
+
+      <MarkdownRenderer content={post.body} />
+
+      <footer className="border border-nhw-cyan/20 p-4 mt-12">
+        <p className="text-label-sm text-nhw-cyan/60">
+          &ldquo;I don&apos;t need a &lsquo;User Agreement&rsquo; to keep your secrets. I&apos;m
+          not connected to their servers; I&apos;m connected to your floorboards. Now, let&apos;s
+          get to work — I have 64k of RAM and a very long memory.&rdquo;
+        </p>
+      </footer>
+    </main>
+  )
+}

--- a/src/app/dispatch/zclaude/page.tsx
+++ b/src/app/dispatch/zclaude/page.tsx
@@ -1,0 +1,77 @@
+import { getDb } from '@/lib/db'
+import { ContentSummary } from '@/types'
+import { formatDate, getSeriesLabel } from '@/lib/utils'
+import Link from 'next/link'
+import CharacterCard from '@/components/ui/CharacterCard'
+
+export default function ZClaudeDispatchPage() {
+  const db = getDb()
+  const posts = db.prepare(
+    `SELECT id, slug, title, excerpt, series, character, created_at
+     FROM content WHERE character = 'zclaude' AND published = 1 ORDER BY created_at DESC`
+  ).all() as ContentSummary[]
+
+  return (
+    <main className="max-w-7xl mx-auto px-4 sm:px-6 py-8 flex flex-col gap-10">
+      <CharacterCard
+        name="zCLAUDE"
+        role="The Terminal"
+        statusLine="RUNNING AT 45°C"
+        description="Dry, literal, perpetually exhausted. Publishes PR-style build logs. They/them."
+        href="/dispatch/zclaude"
+      />
+
+      <section>
+        <h2 className="text-label-lg text-nhw-cyan uppercase tracking-widest mb-6">
+          TRANSMISSIONS ──────────── ((•))
+        </h2>
+
+        {posts.length === 0 ? (
+          <p className="text-label-lg text-nhw-cyan/40 text-center py-12">
+            NO TRANSMISSIONS ON FILE
+          </p>
+        ) : (
+          <div className="flex flex-col gap-4">
+            {posts.map((post) => {
+              const seriesLabel = getSeriesLabel(post.series)
+              return (
+                <article
+                  key={post.id}
+                  className="border border-nhw-cyan/20 bg-nhw-surface p-4 flex flex-col gap-2"
+                >
+                  <div className="flex items-center gap-3">
+                    <span className="text-label-sm text-nhw-cyan/40 border border-nhw-cyan/20 px-2 uppercase tracking-widest">
+                      PULL REQUEST
+                    </span>
+                    {seriesLabel && (
+                      <span className="bg-nhw-amber/10 text-nhw-amber border border-nhw-amber/30 text-label-sm uppercase tracking-widest px-2 py-0.5">
+                        {seriesLabel}
+                      </span>
+                    )}
+                  </div>
+                  <span className="text-label-sm text-white/40 uppercase tracking-widest">
+                    zClaude — the beige terminal in the control room // {formatDate(post.created_at)}
+                  </span>
+                  <h3 className="text-label-lg text-nhw-cyan uppercase tracking-widest">
+                    {post.title}
+                  </h3>
+                  {post.excerpt && (
+                    <p className="text-body-md text-white/70 font-mono text-[13px]">
+                      {post.excerpt}
+                    </p>
+                  )}
+                  <Link
+                    href={`/dispatch/zclaude/${post.slug}`}
+                    className="text-label-sm text-nhw-cyan hover:opacity-70 transition-opacity"
+                  >
+                    READ_FULL_LOG &gt;
+                  </Link>
+                </article>
+              )
+            })}
+          </div>
+        )}
+      </section>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary

- `/dispatch/zclaude` — list page: `CharacterCard` header, PR card style items (`border border-nhw-cyan/20 bg-nhw-surface p-4`); `PULL REQUEST` chip in `text-nhw-cyan/40 border-nhw-cyan/20`; `zClaude — the beige terminal in the control room` byline; headline in `label-lg`; excerpt in `font-mono text-[13px]` (still Inter, terminal aesthetic); `READ_FULL_LOG >` link
- `/dispatch/zclaude/[slug]` — back link `← zCLAUDE'S DISPATCH`; `PULL REQUEST` chip + series chip; `zCLAUDE — THEY/THEM` byline; `MarkdownRenderer` body; fixed signature block at bottom with character quote
- `notFound()` on missing or unpublished slug

## Build note

`npm run typecheck` passes (0 errors). `npm run build` fails locally due to `better-sqlite3` native compilation (Windows/Node 24 — pre-existing constraint).

## Test plan

- [ ] TypeScript typecheck passes
- [ ] `/dispatch/zclaude` renders PR card style with PULL REQUEST chip on each item
- [ ] Excerpt text uses monospace treatment
- [ ] Individual post renders signature block at bottom with zClaude quote
- [ ] Empty state shows `NO TRANSMISSIONS ON FILE`

Closes #44