### PR TITLE
[#56] Hermes draft API endpoint + Pending Review badge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,7 @@ NEXT_PUBLIC_SITE_URL=https://news.ernestofgaia.xyz
 
 # Optional: X (Twitter) handle for "Discuss on X" links
 NEXT_PUBLIC_X_HANDLE=@ErnestOfGaia
+
+# Bearer token for the Hermes publishing agent's POST /api/hermes/draft endpoint.
+# Separate from ADMIN_PASSWORD. Generate a strong random value for production.
+HERMES_API_KEY=change-me-to-a-strong-random-secret

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -61,9 +61,14 @@ export default function AdminPage() {
                       Published
                     </span>
                   ) : (
-                    <span className="bg-stone-100 text-stone-800 text-xs px-2 py-1 rounded-full font-medium">
-                      Draft
-                    </span>
+                    <div className="flex gap-2">
+                      <span className="bg-stone-100 text-stone-800 text-xs px-2 py-1 rounded-full font-medium">
+                        Draft
+                      </span>
+                      <span className="bg-amber-100 text-amber-800 text-xs px-2 py-1 rounded-full font-medium">
+                        Pending Review
+                      </span>
+                    </div>
                   )}
                 </td>
                 <td className="px-6 py-4 text-sm text-stone-600">

--- a/src/app/api/content/route.ts
+++ b/src/app/api/content/route.ts
@@ -1,26 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAdmin } from '@/lib/auth'
 import { getDb } from '@/lib/db'
-import { slugify } from '@/lib/utils'
-import Database from 'better-sqlite3'
-
-function uniqueSlug(db: Database.Database, base: string): string {
-  const rows = db
-    .prepare('SELECT slug FROM content WHERE slug = ? OR slug LIKE ?')
-    .all(base, `${base}-%`) as { slug: string }[]
-
-  const existingSlugs = new Set(rows.map((r) => r.slug))
-
-  if (!existingSlugs.has(base)) {
-    return base
-  }
-
-  let n = 2
-  while (existingSlugs.has(`${base}-${n}`)) {
-    n++
-  }
-  return `${base}-${n}`
-}
+import { slugify, uniqueSlug } from '@/lib/utils'
 
 export async function POST(req: NextRequest) {
   await requireAdmin()

--- a/src/app/api/hermes/draft/route.ts
+++ b/src/app/api/hermes/draft/route.ts
@@ -1,0 +1,107 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { timingSafeEqual } from 'crypto'
+import { getDb } from '@/lib/db'
+import { slugify, uniqueSlug } from '@/lib/utils'
+import type { ContentCharacter, ContentSeries } from '@/types'
+
+const VALID_CHARACTERS = ['pelican', 'gremlin', 'zclaude', 'ag'] as const
+const VALID_SERIES = ['build-log', 'new-news', 'jules-experience', 'pull-request'] as const
+
+function checkBearer(req: NextRequest): { ok: true } | { ok: false; status: number; error: string } {
+  const expected = process.env.HERMES_API_KEY
+  if (!expected) return { ok: false, status: 500, error: 'HERMES_API_KEY not configured' }
+
+  const header = req.headers.get('authorization') ?? ''
+  if (!header.startsWith('Bearer ')) return { ok: false, status: 401, error: 'Unauthorized' }
+
+  const presented = header.slice('Bearer '.length)
+  const a = Buffer.from(presented)
+  const b = Buffer.from(expected)
+  if (a.length !== b.length) return { ok: false, status: 401, error: 'Unauthorized' }
+  if (!timingSafeEqual(a, b)) return { ok: false, status: 401, error: 'Unauthorized' }
+
+  return { ok: true }
+}
+
+interface DraftBody {
+  title?: unknown
+  body?: unknown
+  character?: unknown
+  series?: unknown
+  excerpt?: unknown
+  comic_panels?: unknown
+}
+
+export async function POST(req: NextRequest) {
+  const auth = checkBearer(req)
+  if (!auth.ok) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  let payload: DraftBody
+  try {
+    payload = (await req.json()) as DraftBody
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const title = typeof payload.title === 'string' ? payload.title.trim() : ''
+  const body = typeof payload.body === 'string' ? payload.body.trim() : ''
+  if (!title || !body) {
+    return NextResponse.json({ error: 'title and body are required' }, { status: 400 })
+  }
+
+  let character: ContentCharacter = null
+  if (payload.character !== undefined && payload.character !== null) {
+    if (typeof payload.character !== 'string' || !(VALID_CHARACTERS as readonly string[]).includes(payload.character)) {
+      return NextResponse.json({ error: 'Invalid character' }, { status: 400 })
+    }
+    character = payload.character as ContentCharacter
+  }
+
+  let series: ContentSeries = null
+  if (payload.series !== undefined && payload.series !== null) {
+    if (typeof payload.series !== 'string' || !(VALID_SERIES as readonly string[]).includes(payload.series)) {
+      return NextResponse.json({ error: 'Invalid series' }, { status: 400 })
+    }
+    series = payload.series as ContentSeries
+  }
+
+  let excerpt: string | null = null
+  if (payload.excerpt !== undefined && payload.excerpt !== null) {
+    if (typeof payload.excerpt !== 'string') {
+      return NextResponse.json({ error: 'excerpt must be a string' }, { status: 400 })
+    }
+    const trimmed = payload.excerpt.trim()
+    excerpt = trimmed === '' ? null : trimmed
+  }
+
+  let comicPanels: string | null = null
+  if (payload.comic_panels !== undefined && payload.comic_panels !== null) {
+    if (typeof payload.comic_panels !== 'string') {
+      return NextResponse.json({ error: 'comic_panels must be a JSON string' }, { status: 400 })
+    }
+    try {
+      const parsed: unknown = JSON.parse(payload.comic_panels)
+      if (!Array.isArray(parsed) || !parsed.every((p) => typeof p === 'string')) {
+        return NextResponse.json({ error: 'comic_panels must be a JSON array of strings' }, { status: 400 })
+      }
+      comicPanels = payload.comic_panels
+    } catch {
+      return NextResponse.json({ error: 'comic_panels must be a JSON array of strings' }, { status: 400 })
+    }
+  }
+
+  try {
+    const db = getDb()
+    const slug = uniqueSlug(db, slugify(title))
+    const result = db
+      .prepare(
+        `INSERT INTO content (slug, title, body, excerpt, type, tier, series, character, comic_panels, published)
+         VALUES (?, ?, ?, ?, 'post', 'free', ?, ?, ?, 0)`
+      )
+      .run(slug, title, body, excerpt, series, character, comicPanels)
+    return NextResponse.json({ id: Number(result.lastInsertRowid), slug }, { status: 201 })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Database error'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,3 +1,4 @@
+import type Database from 'better-sqlite3'
 import { ContentSeries } from '@/types'
 
 export function slugify(text: string): string {
@@ -7,6 +8,17 @@ export function slugify(text: string): string {
     .replace(/[^\w\s-]/g, '')
     .replace(/[\s_-]+/g, '-')
     .replace(/^-+|-+$/g, '')
+}
+
+export function uniqueSlug(db: Database.Database, base: string): string {
+  const rows = db
+    .prepare('SELECT slug FROM content WHERE slug = ? OR slug LIKE ?')
+    .all(base, `${base}-%`) as { slug: string }[]
+  const existing = new Set(rows.map((r) => r.slug))
+  if (!existing.has(base)) return base
+  let n = 2
+  while (existing.has(`${base}-${n}`)) n++
+  return `${base}-${n}`
 }
 
 export function formatDate(dateStr: string): string {


### PR DESCRIPTION
## Summary

- New `POST /api/hermes/draft` endpoint, Bearer-token-authenticated via new `HERMES_API_KEY` env var (independent from `ADMIN_PASSWORD`)
- Always writes `published = 0` so Ernest reviews every Hermes draft before going live
- Extracted `uniqueSlug()` from `/api/content/route.ts` into `src/lib/utils.ts` so the new route can reuse it
- Admin list (`/admin`) now renders an amber **Pending Review** pill alongside the gray **Draft** pill for any `published = 0` row

Closes #56

## Verification (local)

- TypeScript strict typecheck: passes
- Auth path (no header / wrong key): returns 401
- Validation (missing title/body, bad JSON, invalid series, malformed `comic_panels`): returns 400 with `{ error }`
- DB write happy path can't run on this Windows host (better-sqlite3 native binding pre-existing local issue, no MSVC C++ tools installed). Bindings will be rebuilt automatically inside the Docker image on the VPS — verify there with the smoke test in the deploy block.

## Deploy notes

- Add `HERMES_API_KEY=<strong production value>` to the VPS `.env` before `docker compose up -d --build`.
- Smoke test on VPS:
  ```bash
  curl -X POST https://news.ernestofgaia.xyz/api/hermes/draft \
    -H "Authorization: Bearer $HERMES_API_KEY" \
    -H "Content-Type: application/json" \
    -d '{"title":"Deploy smoke test","body":"ok"}'
  ```
  Expect `201 { id, slug }`. Then `/admin` should show the new row with the amber Pending Review pill.

## Test plan

- [ ] On VPS after deploy: 401 with no auth header
- [ ] 201 with valid Bearer token + `{title,body}`
- [ ] Second POST with the same title → slug ends with `-2`
- [ ] `/admin` shows amber Pending Review pill on the new draft row
- [ ] Existing admin "New Content" form still saves drafts (`uniqueSlug` extraction is transparent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)