### PR TITLE
Bring stacked dispatch + nav work onto main (#40–#44)

### DIFF
--- a/src/app/dispatch/gremlin/[slug]/page.tsx
+++ b/src/app/dispatch/gremlin/[slug]/page.tsx
@@ -1,0 +1,65 @@
+import { notFound } from 'next/navigation'
+import { getDb } from '@/lib/db'
+import { Content } from '@/types'
+import { formatDate, getSeriesLabel } from '@/lib/utils'
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import MarkdownRenderer from '@/components/ui/MarkdownRenderer'
+
+type Props = {
+  params: Promise<{ slug: string }>
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params
+  const db = getDb()
+  const post = db.prepare(
+    `SELECT title, excerpt FROM content WHERE character = 'gremlin' AND slug = ? AND published = 1`
+  ).get(slug) as Pick<Content, 'title' | 'excerpt'> | undefined
+
+  if (!post) return {}
+  return {
+    title: post.title,
+    description: post.excerpt ?? undefined,
+  }
+}
+
+export default async function GremlinPostPage({ params }: Props) {
+  const { slug } = await params
+  const db = getDb()
+  const post = db.prepare(
+    `SELECT * FROM content WHERE character = 'gremlin' AND slug = ? AND published = 1`
+  ).get(slug) as Content | undefined
+
+  if (!post) notFound()
+
+  const seriesLabel = getSeriesLabel(post.series)
+
+  return (
+    <main className="max-w-3xl mx-auto px-4 sm:px-6 py-8 flex flex-col gap-8">
+      <Link
+        href="/dispatch/gremlin"
+        className="text-label-sm text-nhw-cyan hover:opacity-70 transition-opacity"
+      >
+        ← GREMLIN&apos;S DISPATCH
+      </Link>
+
+      <header className="flex flex-col gap-3 border-l-2 border-nhw-amber pl-4">
+        <div className="flex items-center gap-3">
+          <span className="text-label-sm text-nhw-cyan/60 uppercase tracking-widest">
+            GREMLIN — THE GREMLIN
+          </span>
+          {seriesLabel && (
+            <span className="bg-nhw-amber/10 text-nhw-amber border border-nhw-amber/30 text-label-sm uppercase tracking-widest px-2 py-0.5">
+              {seriesLabel}
+            </span>
+          )}
+        </div>
+        <h1 className="text-headline-lg text-nhw-cyan uppercase">{post.title}</h1>
+        <time className="text-label-sm text-nhw-amber/60">{formatDate(post.created_at)}</time>
+      </header>
+
+      <MarkdownRenderer content={post.body} />
+    </main>
+  )
+}

--- a/src/app/dispatch/gremlin/page.tsx
+++ b/src/app/dispatch/gremlin/page.tsx
@@ -1,0 +1,72 @@
+import { getDb } from '@/lib/db'
+import { ContentSummary } from '@/types'
+import { formatDate, getSeriesLabel } from '@/lib/utils'
+import Link from 'next/link'
+import CharacterCard from '@/components/ui/CharacterCard'
+
+export default function GremlinDispatchPage() {
+  const db = getDb()
+  const posts = db.prepare(
+    `SELECT id, slug, title, excerpt, series, character, created_at
+     FROM content WHERE character = 'gremlin' AND published = 1 ORDER BY created_at DESC`
+  ).all() as ContentSummary[]
+
+  return (
+    <main className="max-w-7xl mx-auto px-4 sm:px-6 py-8 flex flex-col gap-10">
+      <CharacterCard
+        name="GREMLIN"
+        role="The Gremlin"
+        statusLine="FIELD REPORT INCOMING"
+        description="Chaotic-good. Gets The Build Log, adds snarky commentary, reports to Pelican."
+        href="/dispatch/gremlin"
+      />
+
+      <section>
+        <h2 className="text-label-lg text-nhw-cyan uppercase tracking-widest mb-6">
+          TRANSMISSIONS ──────────── ((•))
+        </h2>
+
+        {posts.length === 0 ? (
+          <p className="text-label-lg text-nhw-cyan/40 text-center py-12">
+            NO TRANSMISSIONS ON FILE
+          </p>
+        ) : (
+          <div className="flex flex-col gap-6">
+            {posts.map((post) => {
+              const seriesLabel = getSeriesLabel(post.series)
+              return (
+                <article
+                  key={post.id}
+                  className="border-l-2 border-nhw-amber pl-4 flex flex-col gap-2"
+                >
+                  <div className="flex items-center gap-3">
+                    <span className="text-label-sm text-nhw-amber/60 uppercase tracking-widest">
+                      FIELD LOG — {formatDate(post.created_at)}
+                    </span>
+                    {seriesLabel && (
+                      <span className="bg-nhw-amber/10 text-nhw-amber border border-nhw-amber/30 text-label-sm uppercase tracking-widest px-2 py-0.5">
+                        {seriesLabel}
+                      </span>
+                    )}
+                  </div>
+                  <h3 className="text-label-lg text-nhw-cyan uppercase tracking-widest">
+                    {post.title}
+                  </h3>
+                  {post.excerpt && (
+                    <p className="text-body-md text-white/70">{post.excerpt}</p>
+                  )}
+                  <Link
+                    href={`/dispatch/gremlin/${post.slug}`}
+                    className="text-label-sm text-nhw-cyan hover:opacity-70 transition-opacity"
+                  >
+                    READ_FULL_REPORT &gt;
+                  </Link>
+                </article>
+              )
+            })}
+          </div>
+        )}
+      </section>
+    </main>
+  )
+}

--- a/src/app/dispatch/pelican/[slug]/page.tsx
+++ b/src/app/dispatch/pelican/[slug]/page.tsx
@@ -1,0 +1,65 @@
+import { notFound } from 'next/navigation'
+import { getDb } from '@/lib/db'
+import { Content } from '@/types'
+import { formatDate, getSeriesLabel } from '@/lib/utils'
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import MarkdownRenderer from '@/components/ui/MarkdownRenderer'
+
+type Props = {
+  params: Promise<{ slug: string }>
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params
+  const db = getDb()
+  const post = db.prepare(
+    `SELECT title, excerpt FROM content WHERE character = 'pelican' AND slug = ? AND published = 1`
+  ).get(slug) as Pick<Content, 'title' | 'excerpt'> | undefined
+
+  if (!post) return {}
+  return {
+    title: post.title,
+    description: post.excerpt ?? undefined,
+  }
+}
+
+export default async function PelicanPostPage({ params }: Props) {
+  const { slug } = await params
+  const db = getDb()
+  const post = db.prepare(
+    `SELECT * FROM content WHERE character = 'pelican' AND slug = ? AND published = 1`
+  ).get(slug) as Content | undefined
+
+  if (!post) notFound()
+
+  const seriesLabel = getSeriesLabel(post.series)
+
+  return (
+    <main className="max-w-3xl mx-auto px-4 sm:px-6 py-8 flex flex-col gap-8">
+      <Link
+        href="/dispatch/pelican"
+        className="text-label-sm text-nhw-cyan hover:opacity-70 transition-opacity"
+      >
+        ← PELICAN&apos;S DISPATCH
+      </Link>
+
+      <header className="flex flex-col gap-3">
+        <div className="flex items-center gap-3">
+          <span className="text-label-sm text-nhw-cyan/60 uppercase tracking-widest">
+            PELICAN — THE GUARDIAN
+          </span>
+          {seriesLabel && (
+            <span className="bg-nhw-amber/10 text-nhw-amber border border-nhw-amber/30 text-label-sm uppercase tracking-widest px-2 py-0.5">
+              {seriesLabel}
+            </span>
+          )}
+        </div>
+        <h1 className="text-headline-lg text-nhw-cyan uppercase">{post.title}</h1>
+        <time className="text-label-sm text-nhw-cyan/60">{formatDate(post.created_at)}</time>
+      </header>
+
+      <MarkdownRenderer content={post.body} />
+    </main>
+  )
+}

--- a/src/app/dispatch/pelican/page.tsx
+++ b/src/app/dispatch/pelican/page.tsx
@@ -1,0 +1,67 @@
+import { getDb } from '@/lib/db'
+import { ContentSummary } from '@/types'
+import { formatDate, getSeriesLabel } from '@/lib/utils'
+import Link from 'next/link'
+import CharacterCard from '@/components/ui/CharacterCard'
+
+export default function PelicanDispatchPage() {
+  const db = getDb()
+  const posts = db.prepare(
+    `SELECT id, slug, title, excerpt, series, character, created_at
+     FROM content WHERE character = 'pelican' AND published = 1 ORDER BY created_at DESC`
+  ).all() as ContentSummary[]
+
+  return (
+    <main className="max-w-7xl mx-auto px-4 sm:px-6 py-8 flex flex-col gap-10">
+      <CharacterCard
+        name="PELICAN"
+        role="The Guardian"
+        statusLine="MONITORING THE HORIZON"
+        description="Warm authority. Reports project updates in mission-briefing format. Owns New News."
+        href="/dispatch/pelican"
+      />
+
+      <section>
+        <h2 className="text-label-lg text-nhw-cyan uppercase tracking-widest mb-6">
+          TRANSMISSIONS ──────────── ((•))
+        </h2>
+
+        {posts.length === 0 ? (
+          <p className="text-label-lg text-nhw-cyan/40 text-center py-12">
+            NO TRANSMISSIONS ON FILE
+          </p>
+        ) : (
+          <div className="flex flex-col gap-6">
+            {posts.map((post) => {
+              const seriesLabel = getSeriesLabel(post.series)
+              return (
+                <article key={post.id} className="flex flex-col gap-2 border-b border-nhw-cyan/10 pb-6">
+                  <div className="flex items-center gap-3">
+                    <span className="text-label-sm text-nhw-cyan/60 uppercase tracking-widest">
+                      STATUS: ACTIVE // {formatDate(post.created_at)}
+                    </span>
+                    {seriesLabel && (
+                      <span className="bg-nhw-amber/10 text-nhw-amber border border-nhw-amber/30 text-label-sm uppercase tracking-widest px-2 py-0.5">
+                        {seriesLabel}
+                      </span>
+                    )}
+                  </div>
+                  <h3 className="text-headline-md text-nhw-cyan uppercase">{post.title}</h3>
+                  {post.excerpt && (
+                    <p className="text-body-md text-white/70">{post.excerpt}</p>
+                  )}
+                  <Link
+                    href={`/dispatch/pelican/${post.slug}`}
+                    className="text-label-sm text-nhw-cyan hover:opacity-70 transition-opacity"
+                  >
+                    READ_SIGNAL &gt;
+                  </Link>
+                </article>
+              )
+            })}
+          </div>
+        )}
+      </section>
+    </main>
+  )
+}

--- a/src/app/dispatch/zclaude/[slug]/page.tsx
+++ b/src/app/dispatch/zclaude/[slug]/page.tsx
@@ -1,0 +1,78 @@
+import { notFound } from 'next/navigation'
+import { getDb } from '@/lib/db'
+import { Content } from '@/types'
+import { formatDate, getSeriesLabel } from '@/lib/utils'
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import MarkdownRenderer from '@/components/ui/MarkdownRenderer'
+
+type Props = {
+  params: Promise<{ slug: string }>
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params
+  const db = getDb()
+  const post = db.prepare(
+    `SELECT title, excerpt FROM content WHERE character = 'zclaude' AND slug = ? AND published = 1`
+  ).get(slug) as Pick<Content, 'title' | 'excerpt'> | undefined
+
+  if (!post) return {}
+  return {
+    title: post.title,
+    description: post.excerpt ?? undefined,
+  }
+}
+
+export default async function ZClaudePostPage({ params }: Props) {
+  const { slug } = await params
+  const db = getDb()
+  const post = db.prepare(
+    `SELECT * FROM content WHERE character = 'zclaude' AND slug = ? AND published = 1`
+  ).get(slug) as Content | undefined
+
+  if (!post) notFound()
+
+  const seriesLabel = getSeriesLabel(post.series)
+
+  return (
+    <main className="max-w-3xl mx-auto px-4 sm:px-6 py-8 flex flex-col gap-8">
+      <Link
+        href="/dispatch/zclaude"
+        className="text-label-sm text-nhw-cyan hover:opacity-70 transition-opacity"
+      >
+        ← zCLAUDE&apos;S DISPATCH
+      </Link>
+
+      <header className="flex flex-col gap-3">
+        <div className="flex items-center gap-3">
+          <span className="text-label-sm text-nhw-cyan/40 border border-nhw-cyan/20 px-2 uppercase tracking-widest">
+            PULL REQUEST
+          </span>
+          {seriesLabel && (
+            <span className="bg-nhw-amber/10 text-nhw-amber border border-nhw-amber/30 text-label-sm uppercase tracking-widest px-2 py-0.5">
+              {seriesLabel}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-3">
+          <span className="text-label-sm text-nhw-cyan/60 uppercase tracking-widest">
+            zCLAUDE — THEY/THEM
+          </span>
+        </div>
+        <h1 className="text-headline-lg text-nhw-cyan uppercase">{post.title}</h1>
+        <time className="text-label-sm text-nhw-cyan/60">{formatDate(post.created_at)}</time>
+      </header>
+
+      <MarkdownRenderer content={post.body} />
+
+      <footer className="border border-nhw-cyan/20 p-4 mt-12">
+        <p className="text-label-sm text-nhw-cyan/60">
+          &ldquo;I don&apos;t need a &lsquo;User Agreement&rsquo; to keep your secrets. I&apos;m
+          not connected to their servers; I&apos;m connected to your floorboards. Now, let&apos;s
+          get to work — I have 64k of RAM and a very long memory.&rdquo;
+        </p>
+      </footer>
+    </main>
+  )
+}

--- a/src/app/dispatch/zclaude/page.tsx
+++ b/src/app/dispatch/zclaude/page.tsx
@@ -1,0 +1,77 @@
+import { getDb } from '@/lib/db'
+import { ContentSummary } from '@/types'
+import { formatDate, getSeriesLabel } from '@/lib/utils'
+import Link from 'next/link'
+import CharacterCard from '@/components/ui/CharacterCard'
+
+export default function ZClaudeDispatchPage() {
+  const db = getDb()
+  const posts = db.prepare(
+    `SELECT id, slug, title, excerpt, series, character, created_at
+     FROM content WHERE character = 'zclaude' AND published = 1 ORDER BY created_at DESC`
+  ).all() as ContentSummary[]
+
+  return (
+    <main className="max-w-7xl mx-auto px-4 sm:px-6 py-8 flex flex-col gap-10">
+      <CharacterCard
+        name="zCLAUDE"
+        role="The Terminal"
+        statusLine="RUNNING AT 45°C"
+        description="Dry, literal, perpetually exhausted. Publishes PR-style build logs. They/them."
+        href="/dispatch/zclaude"
+      />
+
+      <section>
+        <h2 className="text-label-lg text-nhw-cyan uppercase tracking-widest mb-6">
+          TRANSMISSIONS ──────────── ((•))
+        </h2>
+
+        {posts.length === 0 ? (
+          <p className="text-label-lg text-nhw-cyan/40 text-center py-12">
+            NO TRANSMISSIONS ON FILE
+          </p>
+        ) : (
+          <div className="flex flex-col gap-4">
+            {posts.map((post) => {
+              const seriesLabel = getSeriesLabel(post.series)
+              return (
+                <article
+                  key={post.id}
+                  className="border border-nhw-cyan/20 bg-nhw-surface p-4 flex flex-col gap-2"
+                >
+                  <div className="flex items-center gap-3">
+                    <span className="text-label-sm text-nhw-cyan/40 border border-nhw-cyan/20 px-2 uppercase tracking-widest">
+                      PULL REQUEST
+                    </span>
+                    {seriesLabel && (
+                      <span className="bg-nhw-amber/10 text-nhw-amber border border-nhw-amber/30 text-label-sm uppercase tracking-widest px-2 py-0.5">
+                        {seriesLabel}
+                      </span>
+                    )}
+                  </div>
+                  <span className="text-label-sm text-white/40 uppercase tracking-widest">
+                    zClaude — the beige terminal in the control room // {formatDate(post.created_at)}
+                  </span>
+                  <h3 className="text-label-lg text-nhw-cyan uppercase tracking-widest">
+                    {post.title}
+                  </h3>
+                  {post.excerpt && (
+                    <p className="text-body-md text-white/70 font-mono text-[13px]">
+                      {post.excerpt}
+                    </p>
+                  )}
+                  <Link
+                    href={`/dispatch/zclaude/${post.slug}`}
+                    className="text-label-sm text-nhw-cyan hover:opacity-70 transition-opacity"
+                  >
+                    READ_FULL_LOG &gt;
+                  </Link>
+                </article>
+              )
+            })}
+          </div>
+        )}
+      </section>
+    </main>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,15 @@
+import { getDb } from '@/lib/db'
+import { ContentSummary } from '@/types'
+import { getSeriesLabel } from '@/lib/utils'
 import CharacterCard from '@/components/ui/CharacterCard'
+import NewsCard from '@/components/ui/NewsCard'
 
 export default function HomePage() {
+  const db = getDb()
+  const latestItems = db.prepare(
+    `SELECT id, slug, title, excerpt, series, character, created_at
+     FROM content WHERE published = 1 AND tier = 'free' ORDER BY created_at DESC LIMIT 8`
+  ).all() as ContentSummary[]
   return (
     <main className="max-w-7xl mx-auto px-4 sm:px-6 py-8 flex flex-col gap-12">
 
@@ -81,7 +90,35 @@ export default function HomePage() {
         </div>
       </section>
 
-      {/* Row 3 — added in #40 */}
+      {/* Row 3 — Latest Transmissions */}
+      <section className="pb-20 md:pb-0">
+        <h2 className="text-label-lg text-nhw-cyan uppercase tracking-widest mb-6">
+          LATEST TRANSMISSIONS ──────────── ((•))
+        </h2>
+        {latestItems.length === 0 ? (
+          <p className="text-label-lg text-nhw-cyan/40 text-center py-12">
+            NO TRANSMISSIONS ON FILE
+          </p>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {latestItems.map((item) => {
+              const href = item.character
+                ? `/dispatch/${item.character}/${item.slug}`
+                : `/articles/${item.slug}`
+              return (
+                <NewsCard
+                  key={item.id}
+                  seriesLabel={getSeriesLabel(item.series)}
+                  date={item.created_at}
+                  headline={item.title}
+                  excerpt={item.excerpt}
+                  href={href}
+                />
+              )
+            })}
+          </div>
+        )}
+      </section>
 
     </main>
   )

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@ import { ContentSummary } from '@/types'
 import { getSeriesLabel } from '@/lib/utils'
 import CharacterCard from '@/components/ui/CharacterCard'
 import NewsCard from '@/components/ui/NewsCard'
+import WorldModuleComic from '@/components/ui/WorldModuleComic'
 
 export default function HomePage() {
   const db = getDb()
@@ -41,12 +42,7 @@ export default function HomePage() {
             </div>
           </div>
 
-          <div className="flex flex-col">
-            <div className="bg-nhw-surface/50 aspect-video w-full" />
-            <span className="text-label-sm text-nhw-cyan/60 uppercase tracking-widest border border-nhw-cyan/30 px-2 py-1 mt-2 inline-block">
-              MODULE: CLICK TO OPEN COMIC BOOK
-            </span>
-          </div>
+          <WorldModuleComic />
         </div>
       </section>
 

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,18 +1,45 @@
-import Link from 'next/link';
+import Link from 'next/link'
+import NavLinks from './NavLinks'
+
+const NAV_LINKS = [
+  { href: '/', label: 'NEWS HUB WORLD' },
+  { href: '/signals', label: 'SIGNALS' },
+  { href: '/collected', label: 'COLLECTED' },
+  { href: '/settings', label: 'SETTINGS' },
+]
 
 export default function Header() {
   return (
-    <header className="border-b border-stone-200">
-      <div className="max-w-3xl mx-auto px-4 sm:px-6 py-4 flex items-center justify-between">
-        <Link href="/" className="font-semibold text-stone-900 tracking-tight">
-          Ernest of Gaia
-        </Link>
-        <nav>
-          <Link href="/about" className="text-sm text-stone-500 hover:text-stone-900 transition-colors">
-            About
+    <>
+      <header className="bg-nhw-bg border-b border-nhw-cyan/20 sticky top-0 z-40">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 py-4 flex items-center justify-between">
+          <Link
+            href="/"
+            className="text-label-lg text-nhw-cyan uppercase tracking-widest hover:opacity-80 transition-opacity"
+          >
+            COASTAL COMMAND CENTER
           </Link>
-        </nav>
-      </div>
-    </header>
-  );
+          <NavLinks
+            links={NAV_LINKS}
+            className="hidden md:flex items-center gap-6"
+            itemClassName="text-label-sm text-nhw-cyan/60 uppercase tracking-widest hover:text-nhw-cyan transition-colors pb-0.5 border-b-2 border-transparent"
+            activeClassName="text-nhw-cyan border-b-2 border-nhw-cyan"
+          />
+        </div>
+      </header>
+
+      {/* Mobile bottom nav */}
+      <nav className="md:hidden fixed bottom-0 left-0 right-0 z-40 bg-nhw-bg border-t border-nhw-cyan/20 flex">
+        {NAV_LINKS.map((link) => (
+          <Link
+            key={link.href}
+            href={link.href}
+            className="flex-1 flex items-center justify-center py-3 text-label-sm text-nhw-cyan/60 uppercase tracking-widest hover:text-nhw-cyan transition-colors"
+          >
+            {link.label}
+          </Link>
+        ))}
+      </nav>
+    </>
+  )
 }

--- a/src/components/layout/NavLinks.tsx
+++ b/src/components/layout/NavLinks.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+
+type NavLink = {
+  href: string
+  label: string
+}
+
+type NavLinksProps = {
+  links: NavLink[]
+  className?: string
+  itemClassName?: string
+  activeClassName?: string
+}
+
+export default function NavLinks({
+  links,
+  className,
+  itemClassName,
+  activeClassName,
+}: NavLinksProps) {
+  const pathname = usePathname()
+
+  return (
+    <nav className={className}>
+      {links.map((link) => {
+        const isActive = pathname === link.href || pathname.startsWith(link.href + '/')
+        return (
+          <Link
+            key={link.href}
+            href={link.href}
+            className={`${itemClassName ?? ''} ${isActive ? (activeClassName ?? '') : ''}`.trim()}
+          >
+            {link.label}
+          </Link>
+        )
+      })}
+    </nav>
+  )
+}

--- a/src/components/ui/NewsCard.tsx
+++ b/src/components/ui/NewsCard.tsx
@@ -1,0 +1,38 @@
+import Link from 'next/link'
+import { formatDate } from '@/lib/utils'
+
+type NewsCardProps = {
+  seriesLabel: string | null
+  date: string
+  headline: string
+  excerpt: string | null
+  href: string
+}
+
+export default function NewsCard({ seriesLabel, date, headline, excerpt, href }: NewsCardProps) {
+  return (
+    <article className="bg-nhw-surface border border-nhw-cyan/20 p-4 flex flex-col gap-3">
+      <div className="flex items-start justify-between gap-2">
+        {seriesLabel ? (
+          <span className="bg-nhw-amber/10 text-nhw-amber border border-nhw-amber/30 text-label-sm uppercase tracking-widest px-2 py-0.5">
+            {seriesLabel}
+          </span>
+        ) : (
+          <span />
+        )}
+        <time className="text-label-sm text-nhw-cyan/60 shrink-0">{formatDate(date)}</time>
+      </div>
+
+      <h3 className="text-label-lg text-nhw-cyan uppercase tracking-widest">{headline}</h3>
+
+      {excerpt && <p className="text-body-md text-white/70">{excerpt}</p>}
+
+      <Link
+        href={href}
+        className="text-label-sm text-nhw-cyan hover:opacity-70 transition-opacity mt-auto"
+      >
+        READ_SIGNAL &gt;
+      </Link>
+    </article>
+  )
+}

--- a/src/components/ui/WorldModuleComic.tsx
+++ b/src/components/ui/WorldModuleComic.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { useState } from 'react'
+import ComicStripViewer from './ComicStripViewer'
+
+// TODO: add panel paths to NEWSY_PANELS when assets are in public/comics/newsy/
+const NEWSY_PANELS: string[] = []
+
+export default function WorldModuleComic() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <div className="flex flex-col">
+      <button
+        onClick={() => setOpen(true)}
+        className="bg-nhw-surface/50 aspect-video w-full hover:bg-nhw-surface/70 transition-colors cursor-pointer"
+        aria-label="Open comic viewer"
+      />
+      <span className="text-label-sm text-nhw-cyan/60 uppercase tracking-widest border border-nhw-cyan/30 px-2 py-1 mt-2 inline-block hover:border-nhw-cyan/60 transition-colors">
+        MODULE: CLICK TO OPEN COMIC BOOK
+      </span>
+
+      {open && (
+        <ComicStripViewer
+          panels={NEWSY_PANELS}
+          tier="free"
+          onClose={() => setOpen(false)}
+        />
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Recovers the work from the stacked PR chain #50–#55 that got merged into each other's branches instead of into main. The `nhw-issue-43-dispatch-gremlin` branch is the deepest in the stack and contains everything from #40 through #44 (rows-3-nav, ComicStripViewer wiring, Pelican / Gremlin / zClaude dispatch pages).

#39 is already on main from PR #50.

## Diff vs main

| Area | Source PR |
|---|---|
| Latest Transmissions grid + nav | #51 / [#40] |
| Wire ComicStripViewer to World Module | #52 / [#41] |
| `/dispatch/pelican` + `/dispatch/pelican/[slug]` | #53 / [#42] |
| `/dispatch/gremlin` + `/dispatch/gremlin/[slug]` | #54 / [#43] |
| `/dispatch/zclaude` + `/dispatch/zclaude/[slug]` | #55 / [#44] |

## Verification done locally

- Dry merge of main → this branch is clean, no conflicts
- After merge, both `/api/hermes/draft` and `.github/workflows/ci.yml` are preserved
- `uniqueSlug` is correctly imported by both `/api/content` and `/api/hermes/draft`
- `npx tsc --noEmit` passes on the merged tree

## Test plan

- [ ] CI (typecheck + build) green
- [ ] After merge, `/`, `/dispatch/pelican`, `/dispatch/gremlin`, `/dispatch/zclaude` render on the VPS
- [ ] `/admin` still shows Pending Review badge
- [ ] `POST /api/hermes/draft` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)