### PR TITLE
Pass HERMES_API_KEY through docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - DATABASE_URL=/app/data/news.db
       - NEXT_PUBLIC_SITE_URL=${NEXT_PUBLIC_SITE_URL}
       - NEXT_PUBLIC_X_HANDLE=${NEXT_PUBLIC_X_HANDLE}
+      - HERMES_API_KEY=${HERMES_API_KEY}
     volumes:
       # Persist the SQLite database across container restarts
       - ./data:/app/data


### PR DESCRIPTION
## Summary

One-line fix: add \`HERMES_API_KEY\` to the \`environment:\` block in \`docker-compose.yml\` so the variable from the VPS \`.env\` actually reaches the Node process inside the container.

Without this, #56's auth check would always fall through to \`500 HERMES_API_KEY not configured\` even with the value set in the host env.

Prerequisite for the first VPS deploy.