### PR TITLE
[#62] force-dynamic on DB-querying static pages

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -3,6 +3,8 @@ import { ContentSummary } from '@/types'
 import Link from 'next/link'
 import { formatDate } from '@/lib/utils'
 
+export const dynamic = 'force-dynamic'
+
 const SERIES_LABELS: Record<string, string> = {
   'build-log': 'The Build Log',
   'new-news': 'New News',

--- a/src/app/dispatch/gremlin/page.tsx
+++ b/src/app/dispatch/gremlin/page.tsx
@@ -4,6 +4,8 @@ import { formatDate, getSeriesLabel } from '@/lib/utils'
 import Link from 'next/link'
 import CharacterCard from '@/components/ui/CharacterCard'
 
+export const dynamic = 'force-dynamic'
+
 export default function GremlinDispatchPage() {
   const db = getDb()
   const posts = db.prepare(

--- a/src/app/dispatch/pelican/page.tsx
+++ b/src/app/dispatch/pelican/page.tsx
@@ -4,6 +4,8 @@ import { formatDate, getSeriesLabel } from '@/lib/utils'
 import Link from 'next/link'
 import CharacterCard from '@/components/ui/CharacterCard'
 
+export const dynamic = 'force-dynamic'
+
 export default function PelicanDispatchPage() {
   const db = getDb()
   const posts = db.prepare(

--- a/src/app/dispatch/zclaude/page.tsx
+++ b/src/app/dispatch/zclaude/page.tsx
@@ -4,6 +4,8 @@ import { formatDate, getSeriesLabel } from '@/lib/utils'
 import Link from 'next/link'
 import CharacterCard from '@/components/ui/CharacterCard'
 
+export const dynamic = 'force-dynamic'
+
 export default function ZClaudeDispatchPage() {
   const db = getDb()
   const posts = db.prepare(

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,8 @@ import CharacterCard from '@/components/ui/CharacterCard'
 import NewsCard from '@/components/ui/NewsCard'
 import WorldModuleComic from '@/components/ui/WorldModuleComic'
 
+export const dynamic = 'force-dynamic'
+
 export default function HomePage() {
   const db = getDb()
   const latestItems = db.prepare(

--- a/src/app/rss.xml/route.ts
+++ b/src/app/rss.xml/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server'
 import { getDb } from '@/lib/db'
 
+export const dynamic = 'force-dynamic'
+
 const BASE = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://news.ernestofgaia.xyz'
 
 export async function GET() {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,6 +1,8 @@
 import type { MetadataRoute } from 'next'
 import { getDb } from '@/lib/db'
 
+export const dynamic = 'force-dynamic'
+
 export default function sitemap(): MetadataRoute.Sitemap {
   const db = getDb()
   const articles = db


### PR DESCRIPTION
## Summary

Adds \`export const dynamic = 'force-dynamic'\` to the 7 static-path pages that query SQLite at render time. Without this, the production Docker build bakes empty-DB HTML into the image.

Closes #62

## Files
- src/app/page.tsx
- src/app/sitemap.ts
- src/app/rss.xml/route.ts
- src/app/admin/page.tsx
- src/app/dispatch/{pelican,gremlin,zclaude}/page.tsx

## Test plan
- [ ] CI green
- [ ] Post-deploy, publishing a draft via /admin shows on / without a rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)