### PR TITLE
Join nginx-proxy network for NPM routing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,3 +13,10 @@ services:
     volumes:
       # Persist the SQLite database across container restarts
       - ./data:/app/data
+    networks:
+      - default
+      - nginx-proxy
+
+networks:
+  nginx-proxy:
+    external: true


### PR DESCRIPTION
Per deployment standards doc — NPM proxies via container service name on the shared `nginx-proxy` network instead of through a host port. This adds news-hub to that external network so NPM can target `news-hub:3000` directly.