### PR TITLE
feat: status/author schema + feed-query swap (#66)

### DIFF
--- a/src/app/dispatch/comics/page.tsx
+++ b/src/app/dispatch/comics/page.tsx
@@ -10,7 +10,7 @@ export default function ComicsDispatchPage() {
   const db = getDb()
   const posts = db.prepare(
     `SELECT id, slug, title, excerpt, series, character, created_at, comic_panels
-     FROM content WHERE character = 'comics' AND published = 1 ORDER BY created_at DESC`
+     FROM content WHERE character = 'comics' AND status = 'published' ORDER BY created_at DESC`
   ).all() as ContentSummary[]
 
   return (

--- a/src/app/dispatch/gremlin/page.tsx
+++ b/src/app/dispatch/gremlin/page.tsx
@@ -10,7 +10,7 @@ export default function GremlinDispatchPage() {
   const db = getDb()
   const posts = db.prepare(
     `SELECT id, slug, title, excerpt, series, character, created_at
-     FROM content WHERE character = 'gremlin' AND published = 1 ORDER BY created_at DESC`
+     FROM content WHERE character = 'gremlin' AND status = 'published' ORDER BY created_at DESC`
   ).all() as ContentSummary[]
 
   return (

--- a/src/app/dispatch/pelican/page.tsx
+++ b/src/app/dispatch/pelican/page.tsx
@@ -12,7 +12,7 @@ export default function PelicanDispatchPage() {
   const db = getDb()
   const posts = db.prepare(
     `SELECT id, slug, title, excerpt, series, character, created_at
-     FROM content WHERE character = 'pelican' AND published = 1 ORDER BY created_at DESC`
+     FROM content WHERE character = 'pelican' AND status = 'published' ORDER BY created_at DESC`
   ).all() as ContentSummary[]
 
   return (

--- a/src/app/dispatch/zclaude/page.tsx
+++ b/src/app/dispatch/zclaude/page.tsx
@@ -10,7 +10,7 @@ export default function ZClaudeDispatchPage() {
   const db = getDb()
   const posts = db.prepare(
     `SELECT id, slug, title, excerpt, series, character, created_at
-     FROM content WHERE character = 'zclaude' AND published = 1 ORDER BY created_at DESC`
+     FROM content WHERE character = 'zclaude' AND status = 'published' ORDER BY created_at DESC`
   ).all() as ContentSummary[]
 
   return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,7 +12,7 @@ export default function HomePage() {
   const db = getDb()
   const latestItems = db.prepare(
     `SELECT id, slug, title, excerpt, series, character, created_at
-     FROM content WHERE published = 1 AND tier = 'free' AND character = 'pelican' ORDER BY created_at DESC LIMIT 4`
+     FROM content WHERE status = 'published' AND tier = 'free' AND character = 'pelican' ORDER BY created_at DESC LIMIT 4`
   ).all() as ContentSummary[]
   return (
     <main className="max-w-7xl mx-auto px-4 sm:px-6 py-8 flex flex-col gap-12">

--- a/src/app/rss.xml/route.ts
+++ b/src/app/rss.xml/route.ts
@@ -9,7 +9,7 @@ export async function GET() {
   const db = getDb()
   const items = db
     .prepare(
-      `SELECT slug, title, excerpt, body, type, created_at FROM content WHERE published=1 AND tier='free' ORDER BY created_at DESC LIMIT 50`
+      `SELECT slug, title, excerpt, body, type, created_at FROM content WHERE status='published' AND tier='free' ORDER BY created_at DESC LIMIT 50`
     )
     .all() as {
     slug: string

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -7,7 +7,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
   const db = getDb()
   const articles = db
     .prepare(
-      `SELECT slug, updated_at FROM content WHERE published=1 AND tier='free' AND type='article' ORDER BY created_at DESC`
+      `SELECT slug, updated_at FROM content WHERE status='published' AND tier='free' AND type='article' ORDER BY created_at DESC`
     )
     .all() as { slug: string; updated_at: string }[]
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -50,4 +50,23 @@ function initSchema(db: Database.Database): void {
   if (!columnNames.includes('comic_panels')) {
     db.exec("ALTER TABLE content ADD COLUMN comic_panels TEXT")
   }
+  // status: 'draft' | 'pending_review' | 'changes_requested' | 'approved' | 'published'
+  if (!columnNames.includes('status')) {
+    db.exec("ALTER TABLE content ADD COLUMN status TEXT NOT NULL DEFAULT 'draft'")
+  }
+  // author: 'ernest' | 'trewkat' | 'hermes'
+  if (!columnNames.includes('author')) {
+    db.exec("ALTER TABLE content ADD COLUMN author TEXT NOT NULL DEFAULT 'ernest'")
+  }
+  if (!columnNames.includes('review_notes')) {
+    db.exec("ALTER TABLE content ADD COLUMN review_notes TEXT")
+  }
+  if (!columnNames.includes('published_at')) {
+    db.exec("ALTER TABLE content ADD COLUMN published_at TEXT")
+  }
+
+  // Backfill status from legacy `published` flag. Idempotent: only flips rows
+  // still on the default 'draft' status. Legacy `published` column is dropped
+  // in a follow-up issue (#72).
+  db.prepare("UPDATE content SET status = 'published' WHERE published = 1 AND status = 'draft'").run()
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,13 @@ export type ContentTier = 'free' | 'premium'
 export type ContentType = 'post' | 'article'
 export type ContentCharacter = 'pelican' | 'gremlin' | 'zclaude' | 'ag' | null
 export type ContentSeries = 'build-log' | 'new-news' | 'jules-experience' | 'pull-request' | null
+export type ContentStatus =
+  | 'draft'
+  | 'pending_review'
+  | 'changes_requested'
+  | 'approved'
+  | 'published'
+export type ContentAuthor = 'ernest' | 'trewkat' | 'hermes'
 
 export interface Content {
   id: number
@@ -15,6 +22,10 @@ export interface Content {
   character: ContentCharacter
   comic_panels: string | null
   published: 0 | 1
+  status: ContentStatus
+  author: ContentAuthor
+  review_notes: string | null
+  published_at: string | null
   x_thread_url: string | null
   created_at: string
   updated_at: string


### PR DESCRIPTION
Closes #66.

Adds the workflow state field so the upcoming Create → Edit → Review → Publish flow has something to operate on. After this slice the public site behaves exactly as before, but each row now carries the columns the later slices need.

## Changes

- `src/lib/db.ts`
  - Idempotent `ALTER TABLE` for `status` (default `'draft'`), `author` (default `'ernest'`), `review_notes` (nullable), `published_at` (nullable), gated on `PRAGMA table_info`.
  - One-shot backfill: `UPDATE content SET status = 'published' WHERE published = 1 AND status = 'draft'`. Idempotent — second run finds zero rows because they're already on `'published'`.
- `src/types/index.ts`
  - New `ContentStatus` union: `'draft' | 'pending_review' | 'changes_requested' | 'approved' | 'published'`
  - New `ContentAuthor` union: `'ernest' | 'trewkat' | 'hermes'`
  - `Content` gains `status`, `author`, `review_notes`, `published_at`. `ContentSummary` (`Omit<Content, 'body'>`) inherits them.
- Public list-view queries swapped from `WHERE published = 1` to `WHERE status = 'published'`:
  - `src/app/page.tsx` (home feed)
  - `src/app/dispatch/{pelican,gremlin,zclaude,comics}/page.tsx`
  - `src/app/sitemap.ts`
  - `src/app/rss.xml/route.ts`

## Acceptance criteria

- [x] `src/lib/db.ts` `initSchema` adds `status`, `author`, `review_notes`, `published_at` idempotently with the specified types/defaults
- [x] One-shot migration `UPDATE content SET status = 'published' WHERE published = 1 AND status = 'draft'` runs in `initSchema` and is idempotent
- [x] `src/types/index.ts` exports `ContentStatus` and `ContentAuthor` and adds the new fields to `Content` / `ContentSummary`
- [x] Public feed query in `src/app/page.tsx` (and the four dispatch list pages, plus `sitemap.ts` / `rss.xml`) filters `WHERE status = 'published'` instead of `WHERE published = 1`
- [x] Legacy `published` column left in place (dropped in #72)
- [x] `npm run typecheck` is clean
- [ ] `npm run lint` — see "Notes for review" below
- [x] Existing published posts continue to render — backfill flips every legacy `published = 1` row to `status = 'published'` on first `initSchema` after deploy

## Notes for review

1. **Detail-page (slug) queries left on `published = 1`.** The AC says "Public feed query in `src/app/page.tsx` (and any list view)", and the work plan said "list view filtering". The single-item slug routes (`articles/[slug]`, `dispatch/*/[slug]`) are not list views, so I left them. They still resolve correctly because the legacy `published` column stays in sync until the API write paths are migrated in #67+. **Should I have swapped these too?** Trivial follow-up if so.

2. **Existing API write paths still set `published`, not `status`.** `api/content/route.ts`, `api/content/[id]/route.ts`, and `api/hermes/draft/route.ts` were not touched (out of scope for #66). Net effect after this slice: any new row written via those endpoints lands as `published=1, status='draft'` and gets flipped to `'published'` only on the next server restart (when `initSchema` re-runs the idempotent backfill). That's fine for staging but means production "publish" actions won't appear on the home feed until the API routes are updated in #67.

3. **`npm run lint` is broken pre-existing in this repo.** There is no `.eslintrc*` / `eslint.config.*` at the project root, so `next lint` (which is also deprecated in Next 16) drops into an interactive ESLint setup wizard and exits non-zero in non-interactive shells. CI doesn't run lint either — `0e54181` ("Drop lint step from CI") removed it. Did not configure ESLint here as that would be scope creep — open a follow-up issue if you want lint re-enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
