### PR TITLE
feat: status state machine + transition API (#67)

### DIFF
--- a/src/app/api/content/[id]/transition/route.ts
+++ b/src/app/api/content/[id]/transition/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/auth'
+import { applyTransition, TransitionError } from '@/lib/content-status'
+import type { ContentStatus } from '@/types'
+
+const VALID_STATUSES: ContentStatus[] = [
+  'draft',
+  'pending_review',
+  'changes_requested',
+  'approved',
+  'published',
+]
+
+function isContentStatus(v: unknown): v is ContentStatus {
+  return typeof v === 'string' && (VALID_STATUSES as string[]).includes(v)
+}
+
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  await requireAdmin()
+
+  const id = parseInt((await params).id)
+  if (isNaN(id)) {
+    return NextResponse.json({ error: 'Invalid ID' }, { status: 400 })
+  }
+
+  let body: { status?: unknown; review_notes?: unknown }
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  if (!isContentStatus(body.status)) {
+    return NextResponse.json({ error: 'Invalid or missing status' }, { status: 400 })
+  }
+
+  const reviewNotes =
+    typeof body.review_notes === 'string' ? body.review_notes : undefined
+
+  try {
+    const row = applyTransition(id, body.status, { reviewNotes })
+    return NextResponse.json(row, { status: 200 })
+  } catch (err) {
+    if (err instanceof TransitionError) {
+      const status = err.code === 'not_found' ? 404 : 400
+      return NextResponse.json({ error: err.message, code: err.code }, { status })
+    }
+    throw err
+  }
+}

--- a/src/lib/content-status.ts
+++ b/src/lib/content-status.ts
@@ -1,0 +1,67 @@
+import { getDb } from './db'
+import type { Content, ContentStatus } from '@/types'
+
+export const ALLOWED_TRANSITIONS: Record<ContentStatus, ContentStatus[]> = {
+  draft: ['pending_review', 'published'],
+  pending_review: ['changes_requested', 'approved'],
+  changes_requested: ['pending_review'],
+  approved: ['published'],
+  published: ['draft'],
+}
+
+export function canTransition(from: ContentStatus, to: ContentStatus): boolean {
+  return ALLOWED_TRANSITIONS[from]?.includes(to) ?? false
+}
+
+export class TransitionError extends Error {
+  code: 'not_found' | 'illegal_transition' | 'missing_review_notes'
+  constructor(code: TransitionError['code'], message: string) {
+    super(message)
+    this.code = code
+  }
+}
+
+export interface ApplyTransitionOptions {
+  reviewNotes?: string | null
+}
+
+export function applyTransition(
+  id: number,
+  to: ContentStatus,
+  { reviewNotes }: ApplyTransitionOptions = {}
+): Content {
+  const db = getDb()
+  const current = db.prepare('SELECT status FROM content WHERE id=?').get(id) as
+    | { status: ContentStatus }
+    | undefined
+
+  if (!current) {
+    throw new TransitionError('not_found', `Content ${id} not found`)
+  }
+  if (!canTransition(current.status, to)) {
+    throw new TransitionError(
+      'illegal_transition',
+      `Cannot transition from ${current.status} to ${to}`
+    )
+  }
+  if (to === 'changes_requested' && !reviewNotes?.trim()) {
+    throw new TransitionError(
+      'missing_review_notes',
+      'review_notes required when transitioning to changes_requested'
+    )
+  }
+
+  const publishedAtParam = to === 'published' ? new Date().toISOString() : null
+  const notesParam = reviewNotes?.trim() || null
+
+  db.prepare(
+    `UPDATE content
+       SET status = ?,
+           review_notes = COALESCE(?, review_notes),
+           published_at = COALESCE(?, published_at),
+           updated_at = datetime('now')
+     WHERE id = ?`
+  ).run(to, notesParam, publishedAtParam, id)
+
+  return db.prepare('SELECT * FROM content WHERE id=?').get(id) as Content
+}


### PR DESCRIPTION
Closes #67.

## Summary

- New `src/lib/content-status.ts`: `ALLOWED_TRANSITIONS`, `canTransition(from, to)`, `applyTransition(id, to, { reviewNotes? })`. `applyTransition` reads current status, validates the transition, and writes a single `UPDATE` that stamps `published_at` only when transitioning to `published` (via `COALESCE(?, published_at)` so non-publish transitions never overwrite an existing stamp).
- New `POST /api/content/[id]/transition` (guarded by `requireAdmin()`). Body: `{ status, review_notes? }`. Returns the updated row on 200, 400 on invalid/illegal/missing-notes, 404 on missing row.

## Acceptance criteria

- [x] `ALLOWED_TRANSITIONS` covers: `draft → pending_review|published`, `pending_review → changes_requested|approved`, `changes_requested → pending_review`, `approved → published`, `published → draft`
- [x] `canTransition` + `applyTransition` exported from `src/lib/content-status.ts`
- [x] Transition route requires admin session
- [x] Illegal transitions → 400
- [x] `→ changes_requested` without `review_notes` → 400
- [x] `published_at` stamped on transition to `published`
- [x] Updated row returned on 200
- [x] `npm run typecheck` clean
- [ ] `npm run lint` — `next lint` is deprecated in Next 15 and prompts interactively for setup; the repo has no ESLint config file. CI runs `typecheck` + `build` only. Flagging so a follow-up can either configure ESLint or drop the `lint` script.

## Verification (curl)

```bash
# legal: draft -> pending_review
curl -X POST http://localhost:3000/api/content/<id>/transition \
  -H "Content-Type: application/json" \
  -b "admin_session=<cookie>" \
  -d '{"status":"pending_review"}'

# illegal: draft -> approved
curl ... -d '{"status":"approved"}'   # → 400

# missing notes
curl ... -d '{"status":"changes_requested"}'   # → 400 missing_review_notes
```

## Notes

- Uses `getDb()` directly (no new helpers in `src/lib/db.ts`) — matches the existing pattern in `src/app/api/content/[id]/route.ts`.
- The route follows the Next 15 async-params shape (`params: Promise<{ id: string }>`).
- No UI changes; Kanban (#69) and edit-page controls (#71) consume this in follow-up slices.

Do not merge — Ernest to review.
