### PR TITLE
feat(#70): drag-to-transition on Kanban board

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "news-hub",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/utilities": "^3.2.2",
         "better-sqlite3": "^11.0.0",
         "next": "^15.0.0",
         "react": "^19.0.0",
@@ -40,6 +42,45 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -378,9 +419,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -396,9 +434,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -416,9 +451,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -434,9 +466,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -454,9 +483,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -472,9 +498,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -492,9 +515,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -511,9 +531,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -529,9 +546,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -555,9 +569,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -579,9 +590,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -605,9 +613,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -629,9 +634,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -655,9 +657,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -680,9 +679,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -704,9 +700,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -906,9 +899,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -924,9 +914,6 @@
       "integrity": "sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -944,9 +931,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -962,9 +946,6 @@
       "integrity": "sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1617,9 +1598,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1634,9 +1612,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1651,9 +1626,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1668,9 +1640,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1685,9 +1654,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1702,9 +1668,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1719,9 +1682,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1736,9 +1696,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/utilities": "^3.2.2",
     "better-sqlite3": "^11.0.0",
     "next": "^15.0.0",
     "react": "^19.0.0",

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,24 +1,9 @@
 import { getDb } from '@/lib/db'
 import { requireAdmin } from '@/lib/auth'
-import { authorChip, voiceChip } from '@/components/admin/chips'
-import type { ContentStatus, ContentSummary } from '@/types'
+import { KanbanBoard, type KanbanRow } from '@/components/admin/KanbanBoard'
 import Link from 'next/link'
-import { formatDate } from '@/lib/utils'
 
 export const dynamic = 'force-dynamic'
-
-const COLUMNS: { status: ContentStatus; label: string }[] = [
-  { status: 'draft', label: 'Draft' },
-  { status: 'pending_review', label: 'Pending Review' },
-  { status: 'changes_requested', label: 'Changes Requested' },
-  { status: 'approved', label: 'Approved' },
-  { status: 'published', label: 'Published' },
-]
-
-type KanbanRow = Pick<
-  ContentSummary,
-  'id' | 'title' | 'author' | 'character' | 'status' | 'updated_at'
->
 
 export default async function AdminPage() {
   await requireAdmin()
@@ -32,10 +17,6 @@ export default async function AdminPage() {
     )
     .all() as KanbanRow[]
 
-  const byStatus = Object.fromEntries(
-    COLUMNS.map(({ status }) => [status, rows.filter((r) => r.status === status)])
-  ) as Record<ContentStatus, KanbanRow[]>
-
   return (
     <main className="p-6 min-h-screen bg-stone-50">
       <div className="flex justify-between items-center mb-8">
@@ -48,59 +29,7 @@ export default async function AdminPage() {
         </Link>
       </div>
 
-      <div className="flex gap-4 overflow-x-auto pb-4">
-        {COLUMNS.map(({ status, label }) => {
-          const cards = byStatus[status]
-          return (
-            <div
-              key={status}
-              className="flex-none w-64 bg-white border border-stone-200 rounded-lg shadow-sm flex flex-col"
-            >
-              <div className="px-4 py-3 border-b border-stone-200 flex justify-between items-center">
-                <span className="text-sm font-semibold text-stone-700">{label}</span>
-                <span className="text-xs text-stone-400 font-medium">{cards.length}</span>
-              </div>
-
-              <div className="flex flex-col gap-2 p-3 flex-1">
-                {cards.length === 0 ? (
-                  <p className="text-xs text-stone-400 text-center py-6">No items</p>
-                ) : (
-                  cards.map((card) => {
-                    const author = authorChip(card.author)
-                    const voice = voiceChip(card.character)
-                    return (
-                      <Link
-                        key={card.id}
-                        href={`/admin/${card.id}`}
-                        className="block bg-stone-50 border border-stone-200 rounded-md p-3 hover:border-stone-400 hover:bg-white transition-colors"
-                      >
-                        <p className="text-sm font-medium text-stone-900 line-clamp-2 mb-2">
-                          {card.title}
-                        </p>
-                        <div className="flex flex-wrap gap-1 mb-2">
-                          <span
-                            className={`inline-block text-xs px-2 py-0.5 rounded-full font-medium ${author.className}`}
-                          >
-                            {author.label}
-                          </span>
-                          {voice && (
-                            <span
-                              className={`inline-block text-xs px-2 py-0.5 rounded-full font-medium ${voice.className}`}
-                            >
-                              {voice.label}
-                            </span>
-                          )}
-                        </div>
-                        <p className="text-xs text-stone-400">{formatDate(card.updated_at)}</p>
-                      </Link>
-                    )
-                  })
-                )}
-              </div>
-            </div>
-          )
-        })}
-      </div>
+      <KanbanBoard initialItems={rows} />
     </main>
   )
 }

--- a/src/components/admin/KanbanBoard.tsx
+++ b/src/components/admin/KanbanBoard.tsx
@@ -1,0 +1,274 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import {
+  DndContext,
+  DragOverlay,
+  useDraggable,
+  useDroppable,
+  type DragEndEvent,
+  type DragStartEvent,
+} from '@dnd-kit/core'
+import { CSS } from '@dnd-kit/utilities'
+import type { ContentStatus, ContentSummary } from '@/types'
+import { canTransition } from '@/lib/content-transitions'
+import { authorChip, voiceChip } from '@/components/admin/chips'
+import Link from 'next/link'
+import { formatDate } from '@/lib/utils'
+
+export type KanbanRow = Pick<
+  ContentSummary,
+  'id' | 'title' | 'author' | 'character' | 'status' | 'updated_at'
+>
+
+const COLUMNS: { status: ContentStatus; label: string }[] = [
+  { status: 'draft', label: 'Draft' },
+  { status: 'pending_review', label: 'Pending Review' },
+  { status: 'changes_requested', label: 'Changes Requested' },
+  { status: 'approved', label: 'Approved' },
+  { status: 'published', label: 'Published' },
+]
+
+interface Toast {
+  message: string
+  ok: boolean
+}
+
+// ─── Card ────────────────────────────────────────────────────────────────────
+
+function KanbanCard({ card }: { card: KanbanRow }) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
+    id: String(card.id),
+    data: card,
+  })
+  const author = authorChip(card.author)
+  const voice = voiceChip(card.character)
+  const style = transform
+    ? { transform: CSS.Transform.toString(transform), opacity: isDragging ? 0.4 : 1 }
+    : undefined
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      {...listeners}
+      {...attributes}
+      className="bg-stone-50 border border-stone-200 rounded-md p-3 cursor-grab active:cursor-grabbing touch-none select-none hover:border-stone-400 hover:bg-white transition-colors"
+    >
+      <Link
+        href={`/admin/${card.id}`}
+        className="block mb-2"
+        draggable={false}
+      >
+        <p className="text-sm font-medium text-stone-900 line-clamp-2">{card.title}</p>
+      </Link>
+      <div className="flex flex-wrap gap-1 mb-2">
+        <span className={`inline-block text-xs px-2 py-0.5 rounded-full font-medium ${author.className}`}>
+          {author.label}
+        </span>
+        {voice && (
+          <span className={`inline-block text-xs px-2 py-0.5 rounded-full font-medium ${voice.className}`}>
+            {voice.label}
+          </span>
+        )}
+      </div>
+      <p className="text-xs text-stone-400">{formatDate(card.updated_at)}</p>
+    </div>
+  )
+}
+
+// ─── Column ──────────────────────────────────────────────────────────────────
+
+function KanbanColumn({
+  status,
+  label,
+  cards,
+}: {
+  status: ContentStatus
+  label: string
+  cards: KanbanRow[]
+}) {
+  const { setNodeRef, isOver } = useDroppable({ id: status })
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={`flex-none w-64 bg-white border rounded-lg shadow-sm flex flex-col transition-colors ${
+        isOver ? 'border-stone-400 bg-stone-50' : 'border-stone-200'
+      }`}
+    >
+      <div className="px-4 py-3 border-b border-stone-200 flex justify-between items-center">
+        <span className="text-sm font-semibold text-stone-700">{label}</span>
+        <span className="text-xs text-stone-400 font-medium">{cards.length}</span>
+      </div>
+      <div className="flex flex-col gap-2 p-3 flex-1 min-h-16">
+        {cards.length === 0 ? (
+          <p className="text-xs text-stone-400 text-center py-6">No items</p>
+        ) : (
+          cards.map((card) => <KanbanCard key={card.id} card={card} />)
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ─── Board ───────────────────────────────────────────────────────────────────
+
+export function KanbanBoard({ initialItems }: { initialItems: KanbanRow[] }) {
+  const [items, setItems] = useState<KanbanRow[]>(initialItems)
+  const [toast, setToast] = useState<Toast | null>(null)
+  const [activeCard, setActiveCard] = useState<KanbanRow | null>(null)
+  // When dragging to 'changes_requested', we pause and ask for review_notes
+  const [pendingDrop, setPendingDrop] = useState<{ contentId: number } | null>(null)
+  const [reviewNotes, setReviewNotes] = useState('')
+
+  useEffect(() => {
+    if (!toast) return
+    const timer = setTimeout(() => setToast(null), 3000)
+    return () => clearTimeout(timer)
+  }, [toast])
+
+  async function doTransition(id: number, toStatus: ContentStatus, notes: string | null) {
+    const snapshot = items
+    setItems((prev) => prev.map((i) => (i.id === id ? { ...i, status: toStatus } : i)))
+
+    const res = await fetch(`/api/content/${id}/transition`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: toStatus, review_notes: notes }),
+    })
+
+    if (res.ok) {
+      const updated = (await res.json()) as KanbanRow
+      setItems((prev) =>
+        prev.map((i) =>
+          i.id === id
+            ? {
+                id: updated.id,
+                title: updated.title,
+                author: updated.author,
+                character: updated.character,
+                status: updated.status,
+                updated_at: updated.updated_at,
+              }
+            : i
+        )
+      )
+      setToast({ message: 'Status updated', ok: true })
+    } else {
+      const data = (await res.json().catch(() => ({}))) as { error?: string }
+      setItems(snapshot)
+      setToast({ message: data.error ?? 'Transition failed', ok: false })
+    }
+  }
+
+  function handleDragStart(event: DragStartEvent) {
+    const card = items.find((i) => String(i.id) === event.active.id)
+    setActiveCard(card ?? null)
+  }
+
+  function handleDragEnd(event: DragEndEvent) {
+    setActiveCard(null)
+    const { active, over } = event
+    if (!over) return
+
+    const toStatus = over.id as ContentStatus
+    const card = items.find((i) => String(i.id) === active.id)
+    if (!card || card.status === toStatus) return
+
+    if (!canTransition(card.status, toStatus)) {
+      setToast({ message: `Cannot move from ${card.status} to ${toStatus}`, ok: false })
+      return
+    }
+
+    if (toStatus === 'changes_requested') {
+      setPendingDrop({ contentId: card.id })
+      setReviewNotes('')
+      return
+    }
+
+    doTransition(card.id, toStatus, null)
+  }
+
+  async function submitModal() {
+    if (!pendingDrop || !reviewNotes.trim()) return
+    await doTransition(pendingDrop.contentId, 'changes_requested', reviewNotes)
+    setPendingDrop(null)
+    setReviewNotes('')
+  }
+
+  function cancelModal() {
+    setPendingDrop(null)
+    setReviewNotes('')
+  }
+
+  const byStatus = Object.fromEntries(
+    COLUMNS.map(({ status }) => [status, items.filter((i) => i.status === status)])
+  ) as Record<ContentStatus, KanbanRow[]>
+
+  return (
+    <>
+      <DndContext onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+        <div className="flex gap-4 overflow-x-auto pb-4">
+          {COLUMNS.map(({ status, label }) => (
+            <KanbanColumn key={status} status={status} label={label} cards={byStatus[status]} />
+          ))}
+        </div>
+        <DragOverlay>
+          {activeCard ? (
+            <div className="bg-white border border-stone-400 rounded-md p-3 shadow-xl rotate-1 w-64 opacity-95">
+              <p className="text-sm font-medium text-stone-900 line-clamp-2">{activeCard.title}</p>
+            </div>
+          ) : null}
+        </DragOverlay>
+      </DndContext>
+
+      {/* Changes-requested modal */}
+      {pendingDrop && (
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+          <div className="bg-white rounded-lg shadow-xl p-6 w-full max-w-md mx-4">
+            <h2 className="text-lg font-semibold text-stone-900 mb-1">Request Changes</h2>
+            <p className="text-sm text-stone-500 mb-4">
+              Describe what needs to change before this can be approved.
+            </p>
+            <textarea
+              // eslint-disable-next-line jsx-a11y/no-autofocus
+              autoFocus
+              value={reviewNotes}
+              onChange={(e) => setReviewNotes(e.target.value)}
+              rows={4}
+              className="w-full px-3 py-2 border border-stone-300 rounded-md text-sm focus:outline-none focus:ring-1 focus:ring-stone-500 mb-4"
+              placeholder="What needs to change…"
+            />
+            <div className="flex justify-end gap-3">
+              <button
+                onClick={cancelModal}
+                className="px-4 py-2 text-sm font-medium text-stone-700 bg-white border border-stone-300 rounded-md hover:bg-stone-50"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={submitModal}
+                disabled={!reviewNotes.trim()}
+                className="px-4 py-2 text-sm font-medium text-white bg-stone-900 rounded-md hover:bg-stone-800 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Submit
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Toast */}
+      {toast && (
+        <div
+          className={`fixed bottom-6 right-6 z-50 px-4 py-3 rounded-lg shadow-lg text-sm font-medium text-white ${
+            toast.ok ? 'bg-green-600' : 'bg-red-600'
+          }`}
+        >
+          {toast.message}
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/lib/content-status.ts
+++ b/src/lib/content-status.ts
@@ -1,17 +1,8 @@
 import { getDb } from './db'
 import type { Content, ContentStatus } from '@/types'
+import { ALLOWED_TRANSITIONS, canTransition } from './content-transitions'
 
-export const ALLOWED_TRANSITIONS: Record<ContentStatus, ContentStatus[]> = {
-  draft: ['pending_review', 'published'],
-  pending_review: ['changes_requested', 'approved'],
-  changes_requested: ['pending_review'],
-  approved: ['published'],
-  published: ['draft'],
-}
-
-export function canTransition(from: ContentStatus, to: ContentStatus): boolean {
-  return ALLOWED_TRANSITIONS[from]?.includes(to) ?? false
-}
+export { ALLOWED_TRANSITIONS, canTransition }
 
 export class TransitionError extends Error {
   code: 'not_found' | 'illegal_transition' | 'missing_review_notes'

--- a/src/lib/content-transitions.ts
+++ b/src/lib/content-transitions.ts
@@ -1,0 +1,13 @@
+import type { ContentStatus } from '@/types'
+
+export const ALLOWED_TRANSITIONS: Record<ContentStatus, ContentStatus[]> = {
+  draft: ['pending_review', 'published'],
+  pending_review: ['changes_requested', 'approved'],
+  changes_requested: ['pending_review'],
+  approved: ['published'],
+  published: ['draft'],
+}
+
+export function canTransition(from: ContentStatus, to: ContentStatus): boolean {
+  return ALLOWED_TRANSITIONS[from]?.includes(to) ?? false
+}


### PR DESCRIPTION
Closes #70

## Changes

- **`@dnd-kit/core` + `@dnd-kit/utilities`** installed (v6.x, React 19 compatible)
- **`src/lib/content-transitions.ts`** (new) — extracts `ALLOWED_TRANSITIONS` and `canTransition` into a pure module with no Node.js dependencies, so client components can import it. `content-status.ts` re-exports both unchanged, preserving the existing import surface.
- **`src/components/admin/KanbanBoard.tsx`** (new, `'use client'`) — full drag-and-drop Kanban board:
  - `DndContext` wraps five `useDroppable` columns; each card is `useDraggable`
  - `DragOverlay` renders a ghost card while dragging
  - `handleDragEnd`: no-op if no drop target; calls `canTransition` (from `content-transitions.ts`) before any API call; illegal drops show an error toast
  - `doTransition`: optimistic update → `POST /api/content/[id]/transition` with `{ status, review_notes }` → on 200 updates card from response; on non-200 reverts state and shows server error message
  - Dropping onto **Changes Requested** opens a modal collecting `review_notes` (required, non-empty) before the POST fires
  - Toast auto-dismisses after 3 s; green = success, red = error
- **`src/app/admin/page.tsx`** — trimmed to a thin server component that auth-guards, queries `id, title, author, character, status, updated_at`, and passes `KanbanRow[]` to `<KanbanBoard initialItems={rows} />`

## AC checklist

- [x] `@dnd-kit/core` dependency added (React 19 compatible) — `package.json` updated
- [x] Cards draggable between columns — `useDraggable` / `useDroppable` wired in `KanbanBoard.tsx`
- [x] Drop POSTs to `/api/content/[id]/transition` — `doTransition` function
- [x] Successful transitions (200): card repositions, `updated_at` refreshed from response
- [x] Failed transitions (400): card reverts, error toast shows server message
- [x] "Changes Requested" drops trigger modal for `review_notes` before submission
- [x] Optimistic updates with error rollback — snapshot captured before fetch, restored on failure
- [x] `npm run typecheck` — clean

## Design note

`content-status.ts` imports `better-sqlite3` transitively, so it cannot be bundled into a client component. Splitting the pure logic into `content-transitions.ts` keeps a single source of truth for allowed transitions while making it importable client-side. Mentioned here rather than in a code comment because the reason is build-system-level, not business-logic.