### PR TITLE
feat(#71): edit page review controls + review_notes

### DIFF
--- a/src/app/admin/[id]/page.tsx
+++ b/src/app/admin/[id]/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import { getDb } from '@/lib/db'
 import { Content } from '@/types'
 import { notFound } from 'next/navigation'
+import { ReviewControls } from '@/components/admin/ReviewControls'
 
 export default async function EditContentPage({ params }: { params: Promise<{ id: string }> }) {
   const id = parseInt((await params).id)
@@ -181,6 +182,13 @@ export default async function EditContentPage({ params }: { params: Promise<{ id
           </div>
         </div>
       </form>
+
+      <ReviewControls
+        id={item.id}
+        currentStatus={item.status}
+        reviewNotes={item.review_notes}
+        author={item.author}
+      />
     </main>
   )
 }

--- a/src/components/admin/ReviewControls.tsx
+++ b/src/components/admin/ReviewControls.tsx
@@ -1,0 +1,196 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import type { ContentAuthor, ContentStatus } from '@/types'
+
+interface Props {
+  id: number
+  currentStatus: ContentStatus
+  reviewNotes: string | null
+  author: ContentAuthor
+}
+
+const STATUS_LABELS: Record<ContentStatus, string> = {
+  draft: 'Draft',
+  pending_review: 'Pending Review',
+  changes_requested: 'Changes Requested',
+  approved: 'Approved',
+  published: 'Published',
+}
+
+const STATUS_COLORS: Record<ContentStatus, string> = {
+  draft: 'bg-stone-100 text-stone-700',
+  pending_review: 'bg-amber-100 text-amber-800',
+  changes_requested: 'bg-red-100 text-red-800',
+  approved: 'bg-green-100 text-green-800',
+  published: 'bg-emerald-100 text-emerald-800',
+}
+
+const AUTHOR_LABELS: Record<ContentAuthor, string> = {
+  ernest: 'Ernest',
+  trewkat: 'Trewkat',
+  hermes: 'Hermes',
+}
+
+export function ReviewControls({ id, currentStatus, reviewNotes, author }: Props) {
+  const router = useRouter()
+  const [localStatus, setLocalStatus] = useState<ContentStatus>(currentStatus)
+  const [localNotes, setLocalNotes] = useState<string | null>(reviewNotes)
+  const [showNotesInput, setShowNotesInput] = useState(false)
+  const [notesInput, setNotesInput] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Sync when server re-renders with fresh props after router.refresh()
+  useEffect(() => { setLocalStatus(currentStatus) }, [currentStatus])
+  useEffect(() => { setLocalNotes(reviewNotes) }, [reviewNotes])
+
+  async function transition(to: ContentStatus, notes?: string) {
+    setSubmitting(true)
+    setError(null)
+    try {
+      const res = await fetch(`/api/content/${id}/transition`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: to, review_notes: notes ?? null }),
+      })
+      if (res.ok) {
+        setLocalStatus(to)
+        setLocalNotes(notes ?? localNotes)
+        setShowNotesInput(false)
+        setNotesInput('')
+        router.refresh()
+      } else {
+        const data = (await res.json().catch(() => ({}))) as { error?: string }
+        setError(data.error ?? 'Transition failed')
+      }
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <section className="mt-8 pt-6 border-t border-stone-200 space-y-4">
+      {/* Status + author row */}
+      <div className="flex flex-wrap items-center gap-3">
+        <span className="text-sm font-medium text-stone-600">Status:</span>
+        <span className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-semibold ${STATUS_COLORS[localStatus]}`}>
+          {STATUS_LABELS[localStatus]}
+        </span>
+        <span className="text-stone-300 select-none">·</span>
+        <span className="text-sm text-stone-500">
+          Author: <span className="font-medium text-stone-700">{AUTHOR_LABELS[author]}</span>
+        </span>
+      </div>
+
+      {/* Existing review_notes callout */}
+      {localNotes && localStatus === 'changes_requested' && (
+        <div className="rounded-md bg-amber-50 border border-amber-200 px-4 py-3 text-sm text-amber-900">
+          <p className="font-semibold mb-1">Changes requested:</p>
+          <p className="whitespace-pre-wrap">{localNotes}</p>
+        </div>
+      )}
+
+      {/* Action buttons */}
+      <div className="flex flex-wrap items-start gap-3">
+        {localStatus === 'draft' && (
+          <button
+            onClick={() => transition('pending_review')}
+            disabled={submitting}
+            className="px-4 py-2 text-sm font-medium text-white bg-stone-900 rounded-md hover:bg-stone-800 disabled:opacity-50"
+          >
+            Submit for review
+          </button>
+        )}
+
+        {localStatus === 'pending_review' && (
+          <>
+            <button
+              onClick={() => transition('approved')}
+              disabled={submitting}
+              className="px-4 py-2 text-sm font-medium text-white bg-green-700 rounded-md hover:bg-green-800 disabled:opacity-50"
+            >
+              Approve
+            </button>
+            <button
+              onClick={() => setShowNotesInput((v) => !v)}
+              disabled={submitting}
+              className="px-4 py-2 text-sm font-medium text-red-700 bg-white border border-red-300 rounded-md hover:bg-red-50 disabled:opacity-50"
+            >
+              Request changes
+            </button>
+          </>
+        )}
+
+        {localStatus === 'changes_requested' && (
+          <button
+            onClick={() => transition('pending_review')}
+            disabled={submitting}
+            className="px-4 py-2 text-sm font-medium text-white bg-amber-600 rounded-md hover:bg-amber-700 disabled:opacity-50"
+          >
+            Resubmit for review
+          </button>
+        )}
+
+        {localStatus === 'approved' && (
+          <button
+            onClick={() => transition('published')}
+            disabled={submitting}
+            className="px-4 py-2 text-sm font-medium text-white bg-emerald-700 rounded-md hover:bg-emerald-800 disabled:opacity-50"
+          >
+            Publish
+          </button>
+        )}
+
+        {localStatus === 'published' && (
+          <button
+            onClick={() => transition('draft')}
+            disabled={submitting}
+            className="px-4 py-2 text-sm font-medium text-red-600 bg-white border border-red-200 rounded-md hover:bg-red-50 disabled:opacity-50"
+          >
+            Unpublish
+          </button>
+        )}
+      </div>
+
+      {/* Review notes input (shown when requesting changes) */}
+      {showNotesInput && (
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-stone-700">
+            Review notes <span className="text-red-500">*</span>
+          </label>
+          <textarea
+            // eslint-disable-next-line jsx-a11y/no-autofocus
+            autoFocus
+            value={notesInput}
+            onChange={(e) => setNotesInput(e.target.value)}
+            rows={4}
+            className="w-full px-3 py-2 border border-stone-300 rounded-md text-sm focus:outline-none focus:ring-1 focus:ring-stone-500"
+            placeholder="Describe what needs to change…"
+          />
+          <div className="flex gap-3">
+            <button
+              onClick={() => transition('changes_requested', notesInput)}
+              disabled={submitting || !notesInput.trim()}
+              className="px-4 py-2 text-sm font-medium text-white bg-red-700 rounded-md hover:bg-red-800 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Submit request
+            </button>
+            <button
+              onClick={() => { setShowNotesInput(false); setNotesInput('') }}
+              disabled={submitting}
+              className="px-4 py-2 text-sm font-medium text-stone-700 bg-white border border-stone-300 rounded-md hover:bg-stone-50"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {error && (
+        <p className="text-sm text-red-600">{error}</p>
+      )}
+    </section>
+  )
+}


### PR DESCRIPTION
Closes #71

## Changes

- **`src/components/admin/ReviewControls.tsx`** (new, `'use client'`) — review workflow controls surfaced on the edit page:
  - Status badge (colour-coded) + author attribution always visible at the bottom of the page
  - Context-dependent action buttons driven by the 5-state machine:
    - `draft` → **Submit for review**
    - `pending_review` → **Approve** + **Request changes**
    - `changes_requested` → **Resubmit for review**
    - `approved` → **Publish**
    - `published` → **Unpublish**
  - "Request changes" reveals a `review_notes` textarea (required, non-empty) with a "Submit request" / "Cancel" pair before any POST fires
  - Existing `review_notes` shown in an amber callout when `status === 'changes_requested'`
  - `POST /api/content/[id]/transition` with `{ status, review_notes }`; on success: `router.refresh()` re-fetches server data; on failure: inline error message
  - `localStatus` and `localNotes` synced from props via `useEffect` so the UI stays consistent after `router.refresh()` delivers new props
- **`src/app/admin/[id]/page.tsx`** — adds `import` and renders `<ReviewControls>` below the save form

## AC checklist

- [x] Current status displayed prominently — colour-coded badge in `ReviewControls`
- [x] Context-dependent action buttons for all 5 status states
- [x] "Request changes" reveals `review_notes` textarea (required non-empty before POST)
- [x] Existing `review_notes` shown in amber callout (only when `status === changes_requested`)
- [x] Author attribution displayed
- [x] `POST /api/content/[id]/transition` called; page refreshes via `router.refresh()`
- [x] `npm run typecheck` — clean

## Note on author editing

The AC mentions "edit permissions for Ernest" on the author field. Displaying author is done; a `<select>` to change it would POST to the existing `/api/content/[id]` route (which doesn't yet accept `author`). Scoped out of this PR to keep it to the AC — flagging here for a follow-up.