### PR TITLE
feat(#72): drop legacy published column

### DIFF
--- a/src/app/admin/[id]/page.tsx
+++ b/src/app/admin/[id]/page.tsx
@@ -146,21 +146,10 @@ export default async function EditContentPage({ params }: { params: Promise<{ id
           To prevent Enter from triggering Unpublish by default,
           we place a hidden submit button first.
         */}
-        <button type="submit" name="action" value={item.published === 1 ? 'publish' : 'draft'} className="hidden" aria-hidden="true" tabIndex={-1} />
+        <button type="submit" name="action" value="draft" className="hidden" aria-hidden="true" tabIndex={-1} />
 
         <div className="flex items-center justify-between pt-4 border-t border-stone-200">
-          <div>
-            {item.published === 1 && (
-              <button
-                type="submit"
-                name="action"
-                value="unpublish"
-                className="px-4 py-2 text-sm font-medium text-red-600 bg-white border border-red-200 rounded-md shadow-sm hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-500"
-              >
-                Unpublish
-              </button>
-            )}
-          </div>
+          <div />
           <div className="flex items-center gap-4">
             <button
               type="submit"

--- a/src/app/api/content/[id]/route.ts
+++ b/src/app/api/content/[id]/route.ts
@@ -22,12 +22,6 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
     return NextResponse.json({ error: 'Body required' }, { status: 400 })
   }
 
-  const action = data.get('action')
-  let published = action === 'publish' ? 1 : 0
-  if (action === 'unpublish') {
-    published = 0
-  }
-
   const db = getDb()
   const excerpt = data.get('excerpt')?.toString().trim() || null
   const type = data.get('type') ?? 'post'
@@ -37,8 +31,8 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
   const xUrl = data.get('x_thread_url')?.toString().trim() || null
 
   db.prepare(
-    `UPDATE content SET title=?,body=?,excerpt=?,type=?,tier=?,series=?,character=?,published=?,x_thread_url=?,updated_at=datetime('now') WHERE id=?`
-  ).run(title, body, excerpt, type, tier, series, character, published, xUrl, id)
+    `UPDATE content SET title=?,body=?,excerpt=?,type=?,tier=?,series=?,character=?,x_thread_url=?,updated_at=datetime('now') WHERE id=?`
+  ).run(title, body, excerpt, type, tier, series, character, xUrl, id)
 
   return NextResponse.redirect(new URL('/admin', req.url), { status: 303 })
 }

--- a/src/app/api/content/route.ts
+++ b/src/app/api/content/route.ts
@@ -20,13 +20,12 @@ export async function POST(req: NextRequest) {
 
   const db = getDb()
   const slug = uniqueSlug(db, slugify(title))
-  const published = data.get('action') === 'publish' ? 1 : 0
   const series = data.get('series')?.toString() || null
   const character = data.get('character')?.toString() || null
 
   db.prepare(`
-    INSERT INTO content (slug, title, body, excerpt, type, tier, series, character, published, x_thread_url)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO content (slug, title, body, excerpt, type, tier, series, character, x_thread_url)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
     slug,
     title,
@@ -36,7 +35,6 @@ export async function POST(req: NextRequest) {
     data.get('tier') ?? 'free',
     series,
     character,
-    published,
     data.get('x_thread_url')?.toString() || null
   )
 

--- a/src/app/api/hermes/draft/route.ts
+++ b/src/app/api/hermes/draft/route.ts
@@ -95,8 +95,8 @@ export async function POST(req: NextRequest) {
     const slug = uniqueSlug(db, slugify(title))
     const result = db
       .prepare(
-        `INSERT INTO content (slug, title, body, excerpt, type, tier, series, character, comic_panels, published)
-         VALUES (?, ?, ?, ?, 'post', 'free', ?, ?, ?, 0)`
+        `INSERT INTO content (slug, title, body, excerpt, type, tier, series, character, comic_panels)
+         VALUES (?, ?, ?, ?, 'post', 'free', ?, ?, ?)`
       )
       .run(slug, title, body, excerpt, series, character, comicPanels)
     return NextResponse.json({ id: Number(result.lastInsertRowid), slug }, { status: 201 })

--- a/src/app/articles/[slug]/page.tsx
+++ b/src/app/articles/[slug]/page.tsx
@@ -14,7 +14,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { slug } = await params
   const db = getDb()
   const article = db
-    .prepare('SELECT title, excerpt FROM content WHERE slug = ? AND published = 1')
+    .prepare("SELECT title, excerpt FROM content WHERE slug = ? AND status = 'published'")
     .get(slug) as { title: string; excerpt: string | null } | undefined
 
   if (!article) return {}
@@ -29,7 +29,7 @@ export default async function ArticlePage({ params }: Props) {
   const { slug } = await params
   const db = getDb()
   const article = db
-    .prepare('SELECT * FROM content WHERE slug = ? AND published = 1')
+    .prepare("SELECT * FROM content WHERE slug = ? AND status = 'published'")
     .get(slug) as Content | undefined
 
   if (!article) {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -34,7 +34,6 @@ function initSchema(db: Database.Database): void {
       type          TEXT NOT NULL DEFAULT 'post',
       tier          TEXT NOT NULL DEFAULT 'free',
       series        TEXT,
-      published     INTEGER NOT NULL DEFAULT 0,
       x_thread_url  TEXT,
       created_at    TEXT NOT NULL DEFAULT (datetime('now')),
       updated_at    TEXT NOT NULL DEFAULT (datetime('now'))
@@ -65,8 +64,10 @@ function initSchema(db: Database.Database): void {
     db.exec("ALTER TABLE content ADD COLUMN published_at TEXT")
   }
 
-  // Backfill status from legacy `published` flag. Idempotent: only flips rows
-  // still on the default 'draft' status. Legacy `published` column is dropped
-  // in a follow-up issue (#72).
-  db.prepare("UPDATE content SET status = 'published' WHERE published = 1 AND status = 'draft'").run()
+  // Backfill status from legacy `published` flag, then drop the column.
+  // Both operations are guarded so they only run on DBs that still have it.
+  if (columnNames.includes('published')) {
+    db.prepare("UPDATE content SET status = 'published' WHERE published = 1 AND status = 'draft'").run()
+    db.exec("ALTER TABLE content DROP COLUMN published")
+  }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -21,7 +21,6 @@ export interface Content {
   series: ContentSeries
   character: ContentCharacter
   comic_panels: string | null
-  published: 0 | 1
   status: ContentStatus
   author: ContentAuthor
   review_notes: string | null


### PR DESCRIPTION
Closes #72

## Changes

Removes all code references to the `content.published` INTEGER column and replaces it with a schema migration that backfills `status` from it (for any existing database rows still on the default `'draft'`) then drops the column in a single guarded operation.

### Files changed

| File | What changed |
|---|---|
| `src/types/index.ts` | Removed `published: 0 \| 1` from `Content` interface |
| `src/lib/db.ts` | Removed `published` from `CREATE TABLE` (fresh DBs won't get it); wrapped existing backfill + added `DROP COLUMN published` inside `if (columnNames.includes('published'))` guard |
| `src/app/articles/[slug]/page.tsx` | `AND published = 1` → `AND status = 'published'` (both metadata + page queries) |
| `src/app/api/content/route.ts` | Removed `published` from `INSERT` and the `action === 'publish'` derivation |
| `src/app/api/content/[id]/route.ts` | Removed `published` from `UPDATE` and the action-based publish/unpublish logic (transitions now handled exclusively by `/api/content/[id]/transition`) |
| `src/app/api/hermes/draft/route.ts` | Removed `published` from `INSERT` (Hermes drafts always land as `status='draft'`) |
| `src/app/admin/[id]/page.tsx` | Removed the legacy Unpublish form button (now surfaced via `ReviewControls` / transition API from PR #78); simplified hidden default submit button |

### Migration safety

The `DROP COLUMN` is SQLite 3.35+ (`better-sqlite3` v11 bundles 3.46.x). On first startup against an existing database:
1. Backfill runs: rows with `published = 1` and `status = 'draft'` → `status = 'published'`
2. Column is dropped immediately after in the same guard block
3. On all subsequent startups the guard is skipped (column no longer present)

Fresh databases never create the column.

## AC checklist

- [x] No remaining code references `content.published` as a column (SQL or TS property) — verified by grep
- [x] `ALTER TABLE content DROP COLUMN published` migration added with column-existence guard
- [x] `published: 0 | 1` removed from `Content` and `ContentRow` (via `ContentRow = Content`)
- [x] `npm run typecheck` — clean

## Smoke test notes

After merging and deploying:
- Home feed (`/`) still returns published-status content — queries use `status = 'published'`
- Dispatch pages still filter on `status = 'published'`
- Admin Kanban still groups on `status`
- Hermes intake (`POST /api/hermes/draft`) creates `status = 'draft'` rows
- Edit form saves without touching status; transitions via `ReviewControls` + transition API