### PR TITLE
feat(#68): Hermes drafts intake — POST /api/drafts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,6 @@ NEXT_PUBLIC_SITE_URL=https://news.ernestofgaia.xyz
 # Optional: X (Twitter) handle for "Discuss on X" links
 NEXT_PUBLIC_X_HANDLE=@ErnestOfGaia
 
-# Bearer token for the Hermes publishing agent's POST /api/hermes/draft endpoint.
+# Bearer token for the Hermes publishing agent (POST /api/drafts).
 # Separate from ADMIN_PASSWORD. Generate a strong random value for production.
 HERMES_API_KEY=change-me-to-a-strong-random-secret

--- a/src/app/api/drafts/route.ts
+++ b/src/app/api/drafts/route.ts
@@ -1,0 +1,97 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireHermesKey } from '@/lib/auth'
+import { getDb } from '@/lib/db'
+import { slugify, uniqueSlug } from '@/lib/utils'
+import type { ContentSeries, ContentType } from '@/types'
+
+const VALID_TYPES: ContentType[] = ['post', 'article']
+const VALID_SERIES: ContentSeries[] = [
+  'build-log',
+  'new-news',
+  'jules-experience',
+  'pull-request',
+]
+
+interface DraftPayload {
+  title?: unknown
+  slug?: unknown
+  body?: unknown
+  excerpt?: unknown
+  type?: unknown
+  series?: unknown
+  x_thread_url?: unknown
+}
+
+export async function POST(req: NextRequest) {
+  if (!requireHermesKey(req)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  let payload: DraftPayload
+  try {
+    payload = (await req.json()) as DraftPayload
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const title = typeof payload.title === 'string' ? payload.title.trim() : ''
+  const body = typeof payload.body === 'string' ? payload.body.trim() : ''
+  if (!title || !body) {
+    return NextResponse.json({ error: 'title and body are required' }, { status: 400 })
+  }
+
+  const excerpt =
+    typeof payload.excerpt === 'string' && payload.excerpt.trim()
+      ? payload.excerpt.trim()
+      : null
+
+  const xThreadUrl =
+    typeof payload.x_thread_url === 'string' && payload.x_thread_url.trim()
+      ? payload.x_thread_url.trim()
+      : null
+
+  let type: ContentType = 'post'
+  if (payload.type !== undefined) {
+    if (!VALID_TYPES.includes(payload.type as ContentType)) {
+      return NextResponse.json(
+        { error: `type must be one of: ${VALID_TYPES.join(', ')}` },
+        { status: 400 }
+      )
+    }
+    type = payload.type as ContentType
+  }
+
+  let series: ContentSeries = null
+  if (payload.series !== undefined && payload.series !== null) {
+    if (!VALID_SERIES.includes(payload.series as ContentSeries)) {
+      return NextResponse.json(
+        { error: `series must be one of: ${VALID_SERIES.join(', ')}` },
+        { status: 400 }
+      )
+    }
+    series = payload.series as ContentSeries
+  }
+
+  try {
+    const db = getDb()
+    const baseSlug =
+      typeof payload.slug === 'string' && payload.slug.trim()
+        ? slugify(payload.slug.trim())
+        : slugify(title)
+    const slug = uniqueSlug(db, baseSlug)
+
+    const result = db
+      .prepare(
+        `INSERT INTO content
+           (slug, title, body, excerpt, type, tier, series, x_thread_url, status, author)
+         VALUES (?, ?, ?, ?, ?, 'free', ?, ?, 'pending_review', 'hermes')`
+      )
+      .run(slug, title, body, excerpt, type, series, xThreadUrl)
+
+    const id = Number(result.lastInsertRowid)
+    return NextResponse.json({ id, adminUrl: `/admin/${id}` }, { status: 201 })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Database error'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,6 +1,7 @@
 import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
-import crypto from 'crypto'
+import crypto, { timingSafeEqual } from 'crypto'
+import type { NextRequest } from 'next/server'
 
 const COOKIE_NAME = 'admin_session'
 const MAX_AGE = 60 * 60 * 24 * 7
@@ -25,4 +26,22 @@ export function verifyPassword(input: string): boolean {
 
 export function sessionCookieOptions() {
   return { name: COOKIE_NAME, value: getToken(), httpOnly: true, sameSite: 'strict' as const, maxAge: MAX_AGE, path: '/' }
+}
+
+export function requireHermesKey(req: NextRequest): boolean {
+  const expected = process.env.HERMES_API_KEY
+  if (!expected) return false
+
+  const header = req.headers.get('authorization') ?? ''
+  if (!header.startsWith('Bearer ')) return false
+
+  const presented = header.slice('Bearer '.length)
+  try {
+    const a = Buffer.from(presented)
+    const b = Buffer.from(expected)
+    if (a.length !== b.length) return false
+    return timingSafeEqual(a, b)
+  } catch {
+    return false
+  }
 }


### PR DESCRIPTION
Closes #68

## Changes

### `src/lib/auth.ts` — `requireHermesKey`

New exported function `requireHermesKey(req: NextRequest): boolean`. Validates the `Authorization: Bearer <key>` header against `HERMES_API_KEY` using `timingSafeEqual` (constant-time comparison to prevent timing attacks). Returns `false` if the env var is not set, the header is missing/malformed, or the key doesn't match. Callers decide the response — this mirrors `checkAdminSession()` and contrasts with `requireAdmin()` which throws a redirect.

### `src/app/api/drafts/route.ts` — new `POST /api/drafts`

| Field | Required | Notes |
|---|---|---|
| `title` | ✓ | Trimmed; used to auto-generate slug if `slug` omitted |
| `body` | ✓ | Trimmed |
| `slug` | — | Slugified + deduplicated via `uniqueSlug`; auto-generated from title if absent |
| `excerpt` | — | Optional string |
| `type` | — | `'post'` (default) or `'article'` |
| `series` | — | One of the four valid series values or omitted |
| `x_thread_url` | — | Optional string |

`status` is hard-coded to `'pending_review'` and `author` to `'hermes'` — any client-supplied values for these are ignored. This means Hermes drafts land directly in the Pending Review column on the Kanban board, ready for Ernest or Trewkat to approve.

Response on 201: `{ id: number, adminUrl: string }` where `adminUrl = /admin/<id>`.

### `.env.example`

Comment updated to reference `/api/drafts`.

## AC checklist

- [x] `HERMES_API_KEY` documented in `.env.example`
- [x] `src/lib/auth.ts` exports `requireHermesKey(req): boolean`
- [x] New `POST /api/drafts` route authenticates via `requireHermesKey`; returns 401 if invalid
- [x] Accepts `title, slug?, body, excerpt?, type, series, x_thread_url?`; auto-generates slug from title if omitted
- [x] Forces `status='pending_review'` and `author='hermes'`; ignores any client-supplied values for these
- [x] Returns `{ id, adminUrl }` pointing to `/admin/<id>`
- [x] `/api/content/[id]/transition` still requires admin cookie — `requireHermesKey` is not wired to it
- [x] `npm run typecheck` — clean

## `curl` verification

```bash
curl -X POST https://news.ernestofgaia.xyz/api/drafts \
  -H "Authorization: Bearer $HERMES_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{
    "title": "Pelican watches the tide",
    "body": "The guardian stood at the shore...",
    "series": "new-news",
    "excerpt": "A moment of stillness."
  }'
# Expected: 201 { "id": N, "adminUrl": "/admin/N" }
# Card appears in Pending Review column on the Kanban board
```